### PR TITLE
Support cancellable async DICOM stream reads

### DIFF
--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -422,7 +422,7 @@ export class AsyncDicomReader {
 
     async readSequence(listener, sqTagInfo, options) {
         const { length } = sqTagInfo;
-        const { stream, syntax } = this;
+        const { stream } = this;
         const endOffset =
             length === UNDEFINED_LENGTH_FIX
                 ? Number.MAX_SAFE_INTEGER
@@ -433,7 +433,7 @@ export class AsyncDicomReader {
             (await stream.ensureAvailable(12))
         ) {
             readLog.debug("readSequence loop", stream.offset, endOffset);
-            const tagInfo = this.readTagHeader(syntax, options);
+            const tagInfo = this.readTagHeader();
             const { tag } = tagInfo;
             if (tag === TagHex.Item) {
                 listener.startObject();
@@ -738,6 +738,16 @@ export class AsyncDicomReader {
         return vr === "SQ" || (vr === "UN" && length === UNDEFINED_LENGTH_FIX);
     }
 
+    normalizeReadOptions(options = {}) {
+        return {
+            ...options,
+            untilTag: DicomMetaDictionary.normalizeTagOption(
+                options.untilTag,
+                "untilTag"
+            )
+        };
+    }
+
     /**
      * Reads a tag header.
      */
@@ -747,6 +757,7 @@ export class AsyncDicomReader {
             includeUntilTagValue: false
         }
     ) {
+        options = this.normalizeReadOptions(options);
         const { stream, syntax } = this;
         const { untilTag, includeUntilTagValue } = options;
         const implicit = syntax == IMPLICIT_LITTLE_ENDIAN;

--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -30,6 +30,7 @@ const readLog = log.getLogger("AsyncDicomReader");
  */
 export class AsyncDicomReader {
     syntax = EXPLICIT_LITTLE_ENDIAN;
+    stopInfo = null;
 
     constructor(options = {}) {
         this.isLittleEndian = options?.isLittleEndian;
@@ -44,6 +45,62 @@ export class AsyncDicomReader {
     /** Sentinel returned when stream is Part 10 but has no preamble (starts with meta). */
     static PART10_NO_PREAMBLE = Symbol("PART10_NO_PREAMBLE");
 
+    static async readFileFromAsyncStream(stream, options = {}) {
+        const { readerOptions, ...readOptions } = options;
+        const reader = new AsyncDicomReader(readerOptions);
+        return reader.readFileFromAsyncStream(stream, readOptions);
+    }
+
+    async readFileFromAsyncStream(stream, options = {}) {
+        const {
+            streamOptions: inputStreamOptions,
+            stopStreamOnComplete = true,
+            ...readOptions
+        } = options;
+        const streamOptions = {
+            maxReadAhead: 1024,
+            ...inputStreamOptions
+        };
+
+        const pump = this.stream.pumpAsyncStream(stream, streamOptions);
+        const awaitAbort = this.shouldAwaitStreamAbort(stream, streamOptions);
+
+        try {
+            const result = await this.readFile(readOptions);
+            if (stopStreamOnComplete) {
+                pump.abort();
+                await this.settlePumpAfterAbort(pump, awaitAbort);
+            }
+            return result;
+        } catch (error) {
+            pump.abort(error);
+            await this.settlePumpAfterAbort(pump, awaitAbort);
+            throw error;
+        }
+    }
+
+    shouldAwaitStreamAbort(stream, streamOptions) {
+        if (streamOptions.awaitAbort !== undefined) {
+            return streamOptions.awaitAbort;
+        }
+        return (
+            streamOptions.destroyOnAbort !== false &&
+            typeof stream.destroy === "function"
+        );
+    }
+
+    async settlePumpAfterAbort(pump, shouldAwait) {
+        const finished = pump.finished.catch(error => {
+            if (!pump.aborted) {
+                throw error;
+            }
+        });
+
+        if (shouldAwait) {
+            await finished;
+        }
+    }
+
     /**
      * Reads the preamble and checks for the DICM marker.
      * Returns true if found/read, leaving the stream past the
@@ -56,7 +113,7 @@ export class AsyncDicomReader {
      */
     async readPreamble() {
         const { stream } = this;
-        await stream.ensureAvailable();
+        await stream.ensureAvailable(132);
         stream.reset();
         stream.increment(128);
         if (stream.readAsciiString(4) !== "DICM") {
@@ -150,6 +207,7 @@ export class AsyncDicomReader {
     }
 
     async readFile(options = undefined) {
+        this.stopInfo = null;
         const hasPreamble = await this.readPreamble();
         if (hasPreamble === AsyncDicomReader.PART10_NO_PREAMBLE) {
             // Part 10 without preamble: stream starts at (0002,0000) or rest of meta
@@ -215,7 +273,7 @@ export class AsyncDicomReader {
      */
     async readMeta(options = undefined) {
         const { stream } = this;
-        await stream.ensureAvailable();
+        await stream.ensureAvailable(12);
         const { offset: metaStartPos } = stream;
         const el = this.readTagHeader();
         if (el.tag !== TagHex.FileMetaInformationGroupLength) {
@@ -260,8 +318,12 @@ export class AsyncDicomReader {
         const untilOffset = options?.untilOffset || Number.MAX_SAFE_INTEGER;
         this.listener = listener;
         const { stream } = this;
-        await stream.ensureAvailable();
-        while (stream.offset < untilOffset && stream.isAvailable(1, false)) {
+        await stream.ensureAvailable(12);
+        while (
+            !this.stopInfo &&
+            stream.offset < untilOffset &&
+            stream.isAvailable(1, false)
+        ) {
             readLog.debug("read loop", stream.offset, untilOffset);
             // Consume before reading the tag so that data before the
             // current tag can be cleared.
@@ -274,6 +336,7 @@ export class AsyncDicomReader {
             // the VR field for explicit-LE).  Callers that need the start
             // offset of the tag itself should subtract 4 from stream.offset.
             if (tagInfo.isUntilTag) {
+                this.setStopInfo("untilTag", tagInfo);
                 break;
             }
 
@@ -306,9 +369,49 @@ export class AsyncDicomReader {
                 await this.readSingle(tagInfo, listener, options);
             }
             listener.pop();
-            await this.stream.ensureAvailable();
+            if (this.stopInfo) {
+                break;
+            }
+            if (await this.shouldStopAfterTag(tagInfo, listener, options)) {
+                break;
+            }
+            await this.stream.ensureAvailable(12);
         }
         return listener.pop();
+    }
+
+    async shouldStopAfterTag(tagInfo, listener, options) {
+        const { shouldStop } = options || {};
+        if (typeof shouldStop !== "function") {
+            return false;
+        }
+
+        const result = await shouldStop({
+            tagInfo,
+            listener,
+            reader: this,
+            stream: this.stream
+        });
+        if (!result) {
+            return false;
+        }
+
+        this.setStopInfo("shouldStop", tagInfo);
+        return true;
+    }
+
+    setStopInfo(reason, tagInfo) {
+        this.stopInfo = {
+            reason,
+            tag: tagInfo.tag,
+            offset: tagInfo.tagStartOffset,
+            tagStartOffset: tagInfo.tagStartOffset,
+            valueOffset: tagInfo.valueOffset,
+            valueLength: tagInfo.length,
+            stopOffset: this.stream.offset,
+            bufferedSize: this.stream.size
+        };
+        return this.stopInfo;
     }
 
     async readSequence(listener, sqTagInfo, options) {
@@ -318,7 +421,11 @@ export class AsyncDicomReader {
             length === UNDEFINED_LENGTH_FIX
                 ? Number.MAX_SAFE_INTEGER
                 : stream.offset + length;
-        while (stream.offset < endOffset && (await stream.ensureAvailable())) {
+        while (
+            !this.stopInfo &&
+            stream.offset < endOffset &&
+            (await stream.ensureAvailable(12))
+        ) {
             readLog.debug("readSequence loop", stream.offset, endOffset);
             const tagInfo = this.readTagHeader(syntax, options);
             const { tag } = tagInfo;
@@ -339,6 +446,9 @@ export class AsyncDicomReader {
                     ...options,
                     untilOffset: itemUntilOffset
                 });
+                if (this.stopInfo) {
+                    return;
+                }
             } else if (tag === TagHex.SequenceDelimitationEnd) {
                 // Sequence of undefined lengths end in sequence delimitation item
                 return;
@@ -632,12 +742,21 @@ export class AsyncDicomReader {
         const implicit = syntax == IMPLICIT_LITTLE_ENDIAN;
         const isLittleEndian = syntax !== EXPLICIT_BIG_ENDIAN;
         stream.setEndian(isLittleEndian);
+        const tagStartOffset = stream.offset;
         const tagObj = Tag.readTag(stream);
         const tag = tagObj.cleanString;
 
         if (untilTag && untilTag === tag) {
             if (!includeUntilTagValue) {
-                return { tag, tagObj, vr: 0, values: 0, isUntilTag: true };
+                return {
+                    tag,
+                    tagObj,
+                    vr: 0,
+                    values: 0,
+                    isUntilTag: true,
+                    tagStartOffset,
+                    stopOffset: stream.offset
+                };
             }
         }
 
@@ -703,7 +822,9 @@ export class AsyncDicomReader {
             tagObj,
             vm: entry?.vm,
             name: entry?.name,
-            length: length === UNDEFINED_LENGTH ? -1 : length
+            length: length === UNDEFINED_LENGTH ? -1 : length,
+            tagStartOffset,
+            valueOffset: stream.offset
         };
         return header;
     }

--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -85,7 +85,6 @@ export class AsyncDicomReader {
         }
         return (
             streamOptions.cancelOnAbort !== false &&
-            streamOptions.destroyOnAbort !== false &&
             (typeof stream.destroy === "function" ||
                 typeof stream.getReader === "function")
         );
@@ -93,13 +92,19 @@ export class AsyncDicomReader {
 
     async settlePumpAfterAbort(pump, shouldAwait) {
         const finished = pump.finished.catch(error => {
-            if (!pump.aborted) {
-                throw error;
+            if (
+                pump.aborted &&
+                ReadBufferStream.isAbortError(error, pump.reason)
+            ) {
+                return;
             }
+            throw error;
         });
 
         if (shouldAwait) {
             await finished;
+        } else {
+            finished.catch(() => {});
         }
     }
 

--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -330,6 +330,12 @@ export class AsyncDicomReader {
             stream.consume();
             const tagInfo = this.readTagHeader(options);
 
+            if (tagInfo.isPastUntilTag) {
+                stream.offset = tagInfo.tagStartOffset;
+                this.setStopInfo("stopOnGreaterTag", tagInfo);
+                break;
+            }
+
             // Stop when the requested tag boundary is reached.  readTagHeader()
             // has already consumed the 4-byte tag but nothing beyond it, so
             // stream.offset now points at the first byte after the tag (i.e.
@@ -442,10 +448,14 @@ export class AsyncDicomReader {
                     itemLength === UNDEFINED_LENGTH_FIX
                         ? endOffset
                         : Math.min(stream.offset + itemLength, endOffset);
-                await this.read(listener, {
+                const itemOptions = {
                     ...options,
+                    untilTag: null,
+                    includeUntilTagValue: false,
+                    stopOnGreaterTag: false,
                     untilOffset: itemUntilOffset
-                });
+                };
+                await this.read(listener, itemOptions);
                 if (this.stopInfo) {
                     return;
                 }
@@ -758,6 +768,18 @@ export class AsyncDicomReader {
                     stopOffset: stream.offset
                 };
             }
+        }
+
+        if (untilTag && options.stopOnGreaterTag && tag > untilTag) {
+            return {
+                tag,
+                tagObj,
+                vr: 0,
+                values: 0,
+                isPastUntilTag: true,
+                tagStartOffset,
+                stopOffset: tagStartOffset
+            };
         }
 
         let length = null;

--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -84,8 +84,10 @@ export class AsyncDicomReader {
             return streamOptions.awaitAbort;
         }
         return (
+            streamOptions.cancelOnAbort !== false &&
             streamOptions.destroyOnAbort !== false &&
-            typeof stream.destroy === "function"
+            (typeof stream.destroy === "function" ||
+                typeof stream.getReader === "function")
         );
     }
 

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -386,8 +386,20 @@ export class BufferStream {
             }
             state.aborted = true;
             state.reason = reason;
-            if (options.destroyOnAbort !== false) {
+            if (
+                options.cancelOnAbort !== false &&
+                options.destroyOnAbort !== false &&
+                typeof stream.destroy === "function"
+            ) {
                 stream.destroy?.(reason);
+            } else if (
+                options.cancelOnAbort !== false &&
+                options.destroyOnAbort !== false
+            ) {
+                state.cancelPromise = BufferStream.cancelSource(
+                    state.cancelSource,
+                    reason
+                );
             }
             this.setComplete();
             this.notifyReadAheadListeners();
@@ -408,12 +420,15 @@ export class BufferStream {
     }
 
     async _pumpAsyncStream(stream, state, options) {
+        const source = BufferStream.asyncSourceFromStream(stream);
+        state.cancelSource = source.cancel;
         try {
-            for await (const chunk of stream) {
-                if (state.aborted) {
+            while (!state.aborted) {
+                const { done, value } = await source.next();
+                if (done || state.aborted) {
                     break;
                 }
-                this.addBuffer(BufferStream.arrayBufferFromChunk(chunk));
+                this.addBuffer(BufferStream.arrayBufferFromChunk(value));
                 await this.waitForReadAhead(options.maxReadAhead, state);
             }
         } catch (error) {
@@ -421,8 +436,42 @@ export class BufferStream {
                 throw error;
             }
         } finally {
+            await state.cancelPromise;
+            source.release?.();
+            state.cancelSource = null;
             this.setComplete();
         }
+    }
+
+    static cancelSource(cancelSource, reason) {
+        try {
+            return Promise.resolve(cancelSource?.(reason)).catch(() => {});
+        } catch {
+            return Promise.resolve();
+        }
+    }
+
+    static asyncSourceFromStream(stream) {
+        if (typeof stream?.getReader === "function") {
+            const reader = stream.getReader();
+            return {
+                next: () => reader.read(),
+                cancel: reason => reader.cancel(reason),
+                release: () => reader.releaseLock()
+            };
+        }
+
+        const iterator = stream?.[Symbol.asyncIterator]?.();
+        if (iterator) {
+            return {
+                next: () => iterator.next(),
+                cancel: reason => iterator.return?.(reason)
+            };
+        }
+
+        throw new TypeError(
+            "Async stream must be an async iterable or ReadableStream"
+        );
     }
 
     static arrayBufferFromChunk(chunk) {

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -11,6 +11,8 @@ export class BufferStream {
     view = new SplitDataView();
     /** The available listeners are those waiting for a query response */
     availableListeners = [];
+    readAheadListeners = [];
+    requestedAvailable = 0;
 
     /** Indicates if this buffer stream is complete/has finished being created */
     isComplete = false;
@@ -32,6 +34,7 @@ export class BufferStream {
     setComplete(value = true) {
         this.isComplete = value;
         this.notifyAvailableListeners();
+        this.notifyReadAheadListeners();
     }
 
     /**
@@ -54,9 +57,15 @@ export class BufferStream {
      */
     ensureAvailable(bytes = 1024) {
         if (!this.isAvailable(bytes)) {
+            this.requestedAvailable = Math.max(this.requestedAvailable, bytes);
+            this.notifyReadAheadListeners();
             return new Promise(resolve => {
                 const recheckAvailable = () => {
                     if (this.isAvailable(bytes)) {
+                        if (this.requestedAvailable <= bytes) {
+                            this.requestedAvailable = 0;
+                        }
+                        this.notifyReadAheadListeners();
                         resolve(true);
                         return;
                     }
@@ -350,21 +359,104 @@ export class BufferStream {
         if (this.offset > this.size) {
             this.size = this.offset;
         }
+        this.notifyReadAheadListeners();
         return step;
     }
 
     /**
      * Reads from an async stream delivering to addBuffer.
      */
-    async fromAsyncStream(stream) {
-        for await (const chunk of stream) {
-            const ab = chunk.buffer.slice(
+    async fromAsyncStream(stream, options = {}) {
+        return this.pumpAsyncStream(stream, options).finished;
+    }
+
+    /**
+     * Starts reading from an async stream and returns a handle that can abort
+     * the source without requiring callers to read the rest of it first.
+     */
+    pumpAsyncStream(stream, options = {}) {
+        const state = {
+            aborted: false,
+            reason: undefined
+        };
+
+        const abort = reason => {
+            if (state.aborted) {
+                return;
+            }
+            state.aborted = true;
+            state.reason = reason;
+            if (options.destroyOnAbort !== false) {
+                stream.destroy?.(reason);
+            }
+            this.setComplete();
+            this.notifyReadAheadListeners();
+        };
+
+        const finished = this._pumpAsyncStream(stream, state, options);
+
+        return {
+            abort,
+            finished,
+            get aborted() {
+                return state.aborted;
+            },
+            get reason() {
+                return state.reason;
+            }
+        };
+    }
+
+    async _pumpAsyncStream(stream, state, options) {
+        try {
+            for await (const chunk of stream) {
+                if (state.aborted) {
+                    break;
+                }
+                this.addBuffer(BufferStream.arrayBufferFromChunk(chunk));
+                await this.waitForReadAhead(options.maxReadAhead, state);
+            }
+        } catch (error) {
+            if (!state.aborted) {
+                throw error;
+            }
+        } finally {
+            this.setComplete();
+        }
+    }
+
+    static arrayBufferFromChunk(chunk) {
+        if (chunk instanceof ArrayBuffer) {
+            return chunk;
+        }
+        if (ArrayBuffer.isView(chunk)) {
+            return chunk.buffer.slice(
                 chunk.byteOffset,
                 chunk.byteOffset + chunk.byteLength
             );
-            this.addBuffer(ab);
         }
-        this.setComplete();
+        throw new TypeError("Async stream chunks must be ArrayBuffer views");
+    }
+
+    async waitForReadAhead(maxReadAhead, state) {
+        if (typeof maxReadAhead !== "number") {
+            return;
+        }
+
+        while (!state.aborted && this.isPastReadAheadLimit(maxReadAhead)) {
+            await new Promise(resolve => {
+                this.readAheadListeners.push(resolve);
+            });
+        }
+    }
+
+    isPastReadAheadLimit(maxReadAhead) {
+        const limit = this.readAheadLimit(maxReadAhead);
+        return limit === 0 ? this.available > 0 : this.available >= limit;
+    }
+
+    readAheadLimit(maxReadAhead) {
+        return Math.max(0, maxReadAhead, this.requestedAvailable);
     }
 
     /**
@@ -393,6 +485,12 @@ export class BufferStream {
     notifyAvailableListeners() {
         const existingListeners = [...this.availableListeners];
         this.availableListeners.splice(0, this.availableListeners.length);
+        existingListeners.forEach(listener => listener());
+    }
+
+    notifyReadAheadListeners() {
+        const existingListeners = [...this.readAheadListeners];
+        this.readAheadListeners.splice(0, this.readAheadListeners.length);
         existingListeners.forEach(listener => listener());
     }
 

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -384,22 +384,23 @@ export class BufferStream {
             if (state.aborted) {
                 return;
             }
+            const abortReason = reason ?? BufferStream.createAbortReason();
             state.aborted = true;
-            state.reason = reason;
-            if (
-                options.cancelOnAbort !== false &&
-                options.destroyOnAbort !== false &&
-                typeof stream.destroy === "function"
-            ) {
-                stream.destroy?.(reason);
-            } else if (
-                options.cancelOnAbort !== false &&
-                options.destroyOnAbort !== false
-            ) {
-                state.cancelPromise = BufferStream.cancelSource(
-                    state.cancelSource,
-                    reason
-                );
+            state.reason = abortReason;
+            if (options.cancelOnAbort !== false) {
+                if (
+                    options.destroyOnAbort !== false &&
+                    typeof stream.destroy === "function"
+                ) {
+                    stream.destroy(abortReason);
+                } else if (typeof stream.destroy !== "function") {
+                    state.cancelPromise = BufferStream.cancelSource(
+                        state.cancelSource,
+                        abortReason
+                    );
+                } else {
+                    state.cancelPromise = Promise.resolve();
+                }
             }
             this.setComplete();
             this.notifyReadAheadListeners();
@@ -432,15 +433,27 @@ export class BufferStream {
                 await this.waitForReadAhead(options.maxReadAhead, state);
             }
         } catch (error) {
-            if (!state.aborted) {
-                throw error;
+            if (
+                state.aborted &&
+                BufferStream.isAbortError(error, state.reason)
+            ) {
+                return;
             }
+            throw error;
         } finally {
             await state.cancelPromise;
             source.release?.();
             state.cancelSource = null;
             this.setComplete();
         }
+    }
+
+    static isAbortError(error, reason) {
+        return error === reason;
+    }
+
+    static createAbortReason() {
+        return new Error("BufferStream aborted");
     }
 
     static cancelSource(cancelSource, reason) {
@@ -486,7 +499,6 @@ export class BufferStream {
         }
         throw new TypeError("Async stream chunks must be ArrayBuffer views");
     }
-
     async waitForReadAhead(maxReadAhead, state) {
         if (typeof maxReadAhead !== "number") {
             return;

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -58,6 +58,7 @@ export class DicomMessage {
             stopOnGreaterTag: false
         }
     ) {
+        options = DicomMessage._normalizeReadOptions(options);
         const { ignoreErrors, untilTag, stopOnGreaterTag } = options;
         var dict = {};
         try {
@@ -212,6 +213,16 @@ export class DicomMessage {
         return dicomDict;
     }
 
+    static _normalizeReadOptions(options = {}) {
+        return {
+            ...options,
+            untilTag: DicomMetaDictionary.normalizeTagOption(
+                options.untilTag,
+                "untilTag"
+            )
+        };
+    }
+
     static writeTagObject(stream, tagString, vr, values, syntax, writeOptions) {
         var tag = Tag.fromString(tagString);
 
@@ -274,6 +285,7 @@ export class DicomMessage {
             includeUntilTagValue: false
         }
     ) {
+        options = DicomMessage._normalizeReadOptions(options);
         const { untilTag, includeUntilTagValue } = options;
         var implicit = syntax == IMPLICIT_LITTLE_ENDIAN ? true : false,
             isLittleEndian =

--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -29,6 +29,26 @@ export class DicomMetaDictionary {
         return tag.substring(1, 10).replace(",", "");
     }
 
+    static normalizeTag(tag) {
+        if (tag === null || tag === undefined) {
+            return tag;
+        }
+        const normalizedTag = String(tag)
+            .replace(/[(),\s]/g, "")
+            .toUpperCase();
+        if (/^[0-9A-F]{8}$/.test(normalizedTag)) {
+            return normalizedTag;
+        }
+    }
+
+    static normalizeTagOption(tag, optionName = "tag") {
+        const normalizedTag = DicomMetaDictionary.normalizeTag(tag);
+        if (tag !== null && tag !== undefined && !normalizedTag) {
+            throw new Error(`Invalid ${optionName}: ${tag}`);
+        }
+        return normalizedTag;
+    }
+
     static parseIntFromTag(tag) {
         const integerValue = parseInt(
             "0x" + DicomMetaDictionary.unpunctuateTag(tag)

--- a/test/DicomMetaDictionary.test.js
+++ b/test/DicomMetaDictionary.test.js
@@ -11,6 +11,73 @@ describe("DicomMetaDictionary", () => {
                     unpunctuatedTag
                 );
             });
+
+            it("returns non-punctuated strings unchanged.", () => {
+                const originalTag = "PixelData";
+
+                expect(DicomMetaDictionary.unpunctuateTag(originalTag)).toBe(
+                    originalTag
+                );
+            });
+        });
+
+        describe("punctuateTag", () => {
+            it("returns private dictionary keys with commas unchanged.", () => {
+                const privateTag = '(0009,"ACUSON",00)';
+
+                expect(DicomMetaDictionary.punctuateTag(privateTag)).toBe(
+                    privateTag
+                );
+            });
+        });
+
+        describe("normalizeTag", () => {
+            it("returns clean uppercase tags for supported tag formats.", () => {
+                const expectedTag = "7FE00010";
+                const tagFormats = [
+                    "7FE00010",
+                    "7fe00010",
+                    "(7FE0,0010)",
+                    "(7fe0,0010)",
+                    "7FE0,0010"
+                ];
+
+                tagFormats.forEach(tag => {
+                    expect(DicomMetaDictionary.normalizeTag(tag)).toBe(
+                        expectedTag
+                    );
+                });
+            });
+
+            it("returns undefined for invalid tag strings.", () => {
+                const invalidTag = "PixelData";
+
+                expect(DicomMetaDictionary.normalizeTag(invalidTag)).toBe(
+                    undefined
+                );
+            });
+        });
+
+        describe("normalizeTagOption", () => {
+            it("returns normalized tags for valid option values.", () => {
+                const originalTag = "(7fe0,0010)";
+                const expectedTag = "7FE00010";
+
+                expect(
+                    DicomMetaDictionary.normalizeTagOption(originalTag)
+                ).toBe(expectedTag);
+            });
+
+            it("throws for invalid option values.", () => {
+                const invalidTag = "PixelData";
+
+                expect(() =>
+                    DicomMetaDictionary.normalizeTagOption(
+                        invalidTag,
+                        "untilTag"
+                    )
+                ).toThrow("Invalid untilTag: PixelData");
+            });
         });
 
         describe("parseIntFromTag", () => {

--- a/test/anonymizer.test.js
+++ b/test/anonymizer.test.js
@@ -1,6 +1,7 @@
 import dcmjs from "../src/index.js";
 import fs from "fs";
 import { validationLog } from "./../src/log.js";
+import { readFileArrayBuffer } from "./testUtils.js";
 
 // Ignore validation errors
 validationLog.setLevel(5);
@@ -41,7 +42,7 @@ it("test_anonymization", () => {
 
 it("test_anonymization_no_change_ref", () => {
     // given
-    const arrayBuffer = fs.readFileSync("test/sample-sr.dcm").buffer;
+    const arrayBuffer = readFileArrayBuffer("test/sample-sr.dcm");
     const dicomDict = DicomMessage.readFile(arrayBuffer);
 
     // multiple value name

--- a/test/async-data.test.js
+++ b/test/async-data.test.js
@@ -124,6 +124,85 @@ describe("AsyncDicomReader", () => {
         expect(source.locked).toBe(false);
     });
 
+    it("rejects when the source fails after enough bytes were buffered.", async () => {
+        const buffer = createSampleDicom();
+        const sourceError = new Error("source failed");
+        let readCount = 0;
+        const source = {
+            [Symbol.asyncIterator]() {
+                return {
+                    next() {
+                        readCount++;
+                        if (readCount === 1) {
+                            return Promise.resolve({
+                                done: false,
+                                value: new Uint8Array(buffer)
+                            });
+                        }
+                        return Promise.reject(sourceError);
+                    },
+                    return() {
+                        return Promise.resolve({ done: true });
+                    }
+                };
+            }
+        };
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+
+        await expect(
+            reader.readFileFromAsyncStream(source, {
+                listener,
+                untilTag: TagHex.PixelData,
+                includeUntilTagValue: false,
+                streamOptions: {
+                    awaitAbort: true,
+                    maxReadAhead: buffer.byteLength + 1
+                }
+            })
+        ).rejects.toBe(sourceError);
+    });
+
+    it("rejects abort-shaped source errors after early stop.", async () => {
+        const buffer = createSampleDicom();
+        const sourceError = new Error("upstream aborted");
+        sourceError.name = "AbortError";
+        let readCount = 0;
+        const source = {
+            [Symbol.asyncIterator]() {
+                return {
+                    next() {
+                        readCount++;
+                        if (readCount === 1) {
+                            return Promise.resolve({
+                                done: false,
+                                value: new Uint8Array(buffer)
+                            });
+                        }
+                        return Promise.reject(sourceError);
+                    },
+                    return() {
+                        return Promise.resolve({ done: true });
+                    }
+                };
+            }
+        };
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+
+        await expect(
+            reader.readFileFromAsyncStream(source, {
+                listener,
+                untilTag: TagHex.PixelData,
+                includeUntilTagValue: false,
+                streamOptions: {
+                    awaitAbort: true,
+                    maxReadAhead: buffer.byteLength + 1
+                }
+            })
+        ).rejects.toBe(sourceError);
+    });
+
     it("stops a node stream when a sorted tag passes the requested untilTag.", async () => {
         const filePath = "test/sample-dicom.dcm";
         const missingTagBeforeRows = "(0028,0009)";

--- a/test/async-data.test.js
+++ b/test/async-data.test.js
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { ReadableStream } from "stream/web";
 import dcmjs from "../src/index.js";
 import {
     TagHex,
@@ -22,6 +23,16 @@ const { DicomMetadataListener } = dcmjs.utilities;
 
 // Ensure DicomMessage is set on DicomDict
 DicomDict.setDicomMessageClass(DicomMessage);
+
+async function waitFor(predicate) {
+    for (let attempts = 0; attempts < 100; attempts++) {
+        if (predicate()) {
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    throw new Error("Timed out waiting for condition");
+}
 
 describe("AsyncDicomReader", () => {
     it("stops a node stream before reading pixel data when untilTag matches.", async () => {
@@ -57,6 +68,60 @@ describe("AsyncDicomReader", () => {
             reader.stopInfo.tagStartOffset + maxReadAhead
         );
         expect(stream.destroyed).toBe(true);
+    });
+
+    it("waits for a ReadableStream source to cancel before resolving.", async () => {
+        const buffer = createSampleDicom();
+        const bytes = new Uint8Array(buffer);
+        const maxReadAhead = 12;
+        const highWaterMark = 4;
+        let offset = 0;
+        let isReadResolved = false;
+        let resolveCancel;
+        const source = new ReadableStream({
+            pull(controller) {
+                if (offset >= bytes.length) {
+                    controller.close();
+                    return;
+                }
+                const nextOffset = Math.min(
+                    offset + highWaterMark,
+                    bytes.length
+                );
+                controller.enqueue(bytes.slice(offset, nextOffset));
+                offset = nextOffset;
+            },
+            cancel() {
+                return new Promise(resolve => {
+                    resolveCancel = resolve;
+                });
+            }
+        });
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+
+        const readPromise = reader
+            .readFileFromAsyncStream(source, {
+                listener,
+                untilTag: TagHex.PixelData,
+                includeUntilTagValue: false,
+                streamOptions: { maxReadAhead }
+            })
+            .then(result => {
+                isReadResolved = true;
+                return result;
+            });
+
+        await waitFor(() => resolveCancel);
+        await Promise.resolve();
+
+        expect(isReadResolved).toBe(false);
+
+        resolveCancel();
+        const { dict } = await readPromise;
+
+        expect(dict[TagHex.PixelData]).toBeUndefined();
+        expect(source.locked).toBe(false);
     });
 
     it("stops a node stream when a sorted tag passes the requested untilTag.", async () => {

--- a/test/async-data.test.js
+++ b/test/async-data.test.js
@@ -24,6 +24,73 @@ const { DicomMetadataListener } = dcmjs.utilities;
 DicomDict.setDicomMessageClass(DicomMessage);
 
 describe("AsyncDicomReader", () => {
+    it("stops a node stream before reading pixel data when untilTag matches.", async () => {
+        const filePath = "test/sample-dicom.dcm";
+        const maxReadAhead = 12;
+        const highWaterMark = 4;
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+        const stream = fs.createReadStream(filePath, {
+            highWaterMark
+        });
+
+        const { dict } = await reader.readFileFromAsyncStream(stream, {
+            listener,
+            untilTag: TagHex.PixelData,
+            includeUntilTagValue: false,
+            streamOptions: { maxReadAhead }
+        });
+
+        expect(dict[TagHex.Rows].Value[0]).toBe(512);
+        expect(dict[TagHex.PixelData]).toBeUndefined();
+        expect(reader.stopInfo).toEqual(
+            expect.objectContaining({
+                reason: "untilTag",
+                tag: TagHex.PixelData
+            })
+        );
+        expect(reader.stopInfo.valueOffset).toBeUndefined();
+        expect(reader.stopInfo.stopOffset).toBe(
+            reader.stopInfo.tagStartOffset + 4
+        );
+        expect(reader.stream.size).toBeLessThanOrEqual(
+            reader.stopInfo.tagStartOffset + maxReadAhead
+        );
+        expect(stream.destroyed).toBe(true);
+    });
+
+    it("stops a node stream after the shouldStop callback accepts a read tag.", async () => {
+        const filePath = "test/sample-dicom.dcm";
+        const fileSize = fs.statSync(filePath).size;
+        const maxReadAhead = 12;
+        const highWaterMark = 4;
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+        const stream = fs.createReadStream(filePath, {
+            highWaterMark
+        });
+
+        const { dict } = await reader.readFileFromAsyncStream(stream, {
+            listener,
+            shouldStop: ({ tagInfo }) => tagInfo.tag === TagHex.Rows,
+            streamOptions: { maxReadAhead }
+        });
+
+        expect(dict[TagHex.Rows].Value[0]).toBe(512);
+        expect(dict[TagHex.PixelData]).toBeUndefined();
+        expect(reader.stopInfo).toEqual(
+            expect.objectContaining({
+                reason: "shouldStop",
+                tag: TagHex.Rows
+            })
+        );
+        expect(reader.stopInfo.valueOffset).toBeLessThan(
+            reader.stopInfo.stopOffset
+        );
+        expect(reader.stream.size).toBeLessThan(fileSize);
+        expect(stream.destroyed).toBe(true);
+    });
+
     test("DICOM part 10 complete listener uncompressed", async () => {
         const buffer = fs.readFileSync("test/sample-dicom.dcm");
         const reader = new AsyncDicomReader();

--- a/test/async-data.test.js
+++ b/test/async-data.test.js
@@ -61,7 +61,7 @@ describe("AsyncDicomReader", () => {
 
     it("stops a node stream when a sorted tag passes the requested untilTag.", async () => {
         const filePath = "test/sample-dicom.dcm";
-        const missingTagBeforeRows = "00280009";
+        const missingTagBeforeRows = "(0028,0009)";
         const maxReadAhead = 12;
         const highWaterMark = 4;
         const reader = new AsyncDicomReader();
@@ -87,6 +87,23 @@ describe("AsyncDicomReader", () => {
         );
         expect(reader.stopInfo.stopOffset).toBe(reader.stopInfo.tagStartOffset);
         expect(stream.destroyed).toBe(true);
+    });
+
+    it("throws when untilTag is not a valid tag.", async () => {
+        const buffer = fs.readFileSync("test/sample-dicom.dcm");
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+
+        reader.stream.addBuffer(buffer);
+        reader.stream.setComplete();
+
+        await expect(
+            reader.readFile({
+                listener,
+                untilTag: "PixelData",
+                includeUntilTagValue: false
+            })
+        ).rejects.toThrow("Invalid untilTag: PixelData");
     });
 
     it("does not apply top-level sorted tag stops inside sequence items.", async () => {

--- a/test/async-data.test.js
+++ b/test/async-data.test.js
@@ -59,6 +59,119 @@ describe("AsyncDicomReader", () => {
         expect(stream.destroyed).toBe(true);
     });
 
+    it("stops a node stream when a sorted tag passes the requested untilTag.", async () => {
+        const filePath = "test/sample-dicom.dcm";
+        const missingTagBeforeRows = "00280009";
+        const maxReadAhead = 12;
+        const highWaterMark = 4;
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+        const stream = fs.createReadStream(filePath, {
+            highWaterMark
+        });
+
+        const { dict } = await reader.readFileFromAsyncStream(stream, {
+            listener,
+            untilTag: missingTagBeforeRows,
+            stopOnGreaterTag: true,
+            streamOptions: { maxReadAhead }
+        });
+
+        expect(dict[TagHex.Rows]).toBeUndefined();
+        expect(dict[TagHex.PixelData]).toBeUndefined();
+        expect(reader.stopInfo).toEqual(
+            expect.objectContaining({
+                reason: "stopOnGreaterTag",
+                tag: TagHex.Rows
+            })
+        );
+        expect(reader.stopInfo.stopOffset).toBe(reader.stopInfo.tagStartOffset);
+        expect(stream.destroyed).toBe(true);
+    });
+
+    it("does not apply top-level sorted tag stops inside sequence items.", async () => {
+        const missingTagBeforeRows = "00280009";
+        const referencedSeriesSequence = "00081115";
+        const nestedRows = 7;
+        const buffer = createSampleDicom({
+            dict: {
+                [referencedSeriesSequence]: {
+                    vr: "SQ",
+                    Value: [
+                        {
+                            [TagHex.Rows]: {
+                                vr: "US",
+                                Value: [nestedRows]
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+
+        reader.stream.addBuffer(buffer);
+        reader.stream.setComplete();
+        const { dict } = await reader.readFile({
+            listener,
+            untilTag: missingTagBeforeRows,
+            stopOnGreaterTag: true
+        });
+
+        expect(
+            dict[referencedSeriesSequence].Value[0][TagHex.Rows].Value[0]
+        ).toBe(nestedRows);
+        expect(dict[TagHex.Rows]).toBeUndefined();
+        expect(reader.stopInfo).toEqual(
+            expect.objectContaining({
+                reason: "stopOnGreaterTag",
+                tag: TagHex.Rows
+            })
+        );
+    });
+
+    it("does not apply top-level untilTag matches inside sequence items.", async () => {
+        const referencedSeriesSequence = "00081115";
+        const nestedRows = 7;
+        const buffer = createSampleDicom({
+            dict: {
+                [referencedSeriesSequence]: {
+                    vr: "SQ",
+                    Value: [
+                        {
+                            [TagHex.Rows]: {
+                                vr: "US",
+                                Value: [nestedRows]
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+
+        reader.stream.addBuffer(buffer);
+        reader.stream.setComplete();
+        const { dict } = await reader.readFile({
+            listener,
+            untilTag: TagHex.Rows,
+            includeUntilTagValue: false
+        });
+
+        expect(
+            dict[referencedSeriesSequence].Value[0][TagHex.Rows].Value[0]
+        ).toBe(nestedRows);
+        expect(dict[TagHex.Rows]).toBeUndefined();
+        expect(reader.stopInfo).toEqual(
+            expect.objectContaining({
+                reason: "untilTag",
+                tag: TagHex.Rows
+            })
+        );
+    });
+
     it("stops a node stream after the shouldStop callback accepts a read tag.", async () => {
         const filePath = "test/sample-dicom.dcm";
         const fileSize = fs.statSync(filePath).size;

--- a/test/data-options.test.js
+++ b/test/data-options.test.js
@@ -44,6 +44,29 @@ it("test_untilTag", () => {
     expect(dataset.PixelData).toEqual(0);
 });
 
+it("normalizes untilTag before reading a file", () => {
+    const buffer = fs.readFileSync("test/sample-dicom.dcm");
+    const dicomData = DicomMessage.readFile(buffer.buffer, {
+        untilTag: "(7fe0,0010)",
+        includeUntilTagValue: false
+    });
+
+    const dataset = DicomMetaDictionary.naturalizeDataset(dicomData.dict);
+
+    expect(dataset.PixelData).toEqual(0);
+});
+
+it("throws when untilTag is not a valid tag", () => {
+    const buffer = fs.readFileSync("test/sample-dicom.dcm");
+
+    expect(() =>
+        DicomMessage.readFile(buffer.buffer, {
+            untilTag: "PixelData",
+            includeUntilTagValue: false
+        })
+    ).toThrow("Invalid untilTag: PixelData");
+});
+
 it("noCopy multiframe DICOM which has trailing padding", async () => {
     const url =
         "https://github.com/dcmjs-org/data/releases/download/binary-parsing-stressors/multiframe-ultrasound.dcm";

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -5,7 +5,11 @@ import path from "path";
 import { WriteBufferStream } from "../src/BufferStream";
 import dcmjs from "../src/index.js";
 import { log } from "./../src/log.js";
-import { getTestDataset, getZippedTestDataset } from "./testUtils.js";
+import {
+    getTestDataset,
+    getZippedTestDataset,
+    readFileArrayBuffer
+} from "./testUtils.js";
 
 import { promisify } from "util";
 import arrayItem from "./arrayItem.json";
@@ -985,8 +989,8 @@ describe("The same DICOM file loaded from both DCM and JSON", () => {
     let jsonData;
 
     beforeEach(() => {
-        const file = fs.readFileSync("test/sample-sr.dcm");
-        dicomData = dcmjs.data.DicomMessage.readFile(file.buffer, {
+        const arrayBuffer = readFileArrayBuffer("test/sample-sr.dcm");
+        dicomData = dcmjs.data.DicomMessage.readFile(arrayBuffer, {
             // ignoreErrors: true,
         });
         jsonData = JSON.parse(JSON.stringify(sampleDicomSR));

--- a/test/readBufferStream.test.js
+++ b/test/readBufferStream.test.js
@@ -1,4 +1,5 @@
 import { ReadBufferStream } from "../src/BufferStream";
+import { ReadableStream } from "stream/web";
 
 const size = 128;
 const buffer = new ArrayBuffer(size);
@@ -153,6 +154,64 @@ describe("ReadBufferStream Tests", () => {
             expect(stream.isAvailable(remaining + 1)).toBe(true);
             expect(stream.isAvailable(remaining, false)).toBe(true);
             expect(stream.isAvailable(remaining + 1, false)).toBe(false);
+        });
+    });
+
+    describe("async stream pumping", () => {
+        it("reads chunks from a ReadableStream source.", async () => {
+            const source = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2]));
+                    controller.enqueue(new Uint8Array([3]));
+                    controller.close();
+                }
+            });
+            const stream = new ReadBufferStream(null, false);
+
+            await stream.fromAsyncStream(source);
+            stream.reset();
+
+            expect(stream.readUint8()).toBe(1);
+            expect(stream.readUint8()).toBe(2);
+            expect(stream.readUint8()).toBe(3);
+            expect(source.locked).toBe(false);
+        });
+
+        it("cancels a ReadableStream source when aborted.", async () => {
+            const cancelReason = new Error("stop reading");
+            let receivedCancelReason;
+            let resolveCancel;
+            let isFinished = false;
+            const source = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3]));
+                },
+                cancel(reason) {
+                    receivedCancelReason = reason;
+                    return new Promise(resolve => {
+                        resolveCancel = resolve;
+                    });
+                }
+            });
+            const stream = new ReadBufferStream(null, false);
+            const pump = stream.pumpAsyncStream(source, { maxReadAhead: 1 });
+
+            await stream.ensureAvailable(1);
+            pump.abort(cancelReason);
+            const finished = pump.finished.then(() => {
+                isFinished = true;
+            });
+            await Promise.resolve();
+
+            expect(isFinished).toBe(false);
+
+            resolveCancel();
+            await finished;
+
+            expect(receivedCancelReason).toBe(cancelReason);
+            expect(pump.aborted).toBe(true);
+            expect(stream.isComplete).toBe(true);
+            expect(source.locked).toBe(false);
         });
     });
 });

--- a/test/readBufferStream.test.js
+++ b/test/readBufferStream.test.js
@@ -1,4 +1,5 @@
 import { ReadBufferStream } from "../src/BufferStream";
+import { Readable } from "stream";
 import { ReadableStream } from "stream/web";
 
 const size = 128;
@@ -212,6 +213,21 @@ describe("ReadBufferStream Tests", () => {
             expect(pump.aborted).toBe(true);
             expect(stream.isComplete).toBe(true);
             expect(source.locked).toBe(false);
+        });
+
+        it("does not destroy a Node stream when destroyOnAbort is false.", async () => {
+            const source = Readable.from([new Uint8Array([1, 2, 3])]);
+            const stream = new ReadBufferStream(null, false);
+            const pump = stream.pumpAsyncStream(source, {
+                destroyOnAbort: false,
+                maxReadAhead: 1
+            });
+
+            await stream.ensureAvailable(1);
+            pump.abort(new Error("stop reading"));
+            await pump.finished;
+
+            expect(source.destroyed).toBe(false);
         });
     });
 });

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -82,4 +82,20 @@ async function getTestDataset(url, filename) {
     return targetPath;
 }
 
-export { getTestDataset, getZippedTestDataset };
+function bufferToArrayBuffer(buffer) {
+    return buffer.buffer.slice(
+        buffer.byteOffset,
+        buffer.byteOffset + buffer.byteLength
+    );
+}
+
+function readFileArrayBuffer(filePath) {
+    return bufferToArrayBuffer(fs.readFileSync(filePath));
+}
+
+export {
+    bufferToArrayBuffer,
+    getTestDataset,
+    getZippedTestDataset,
+    readFileArrayBuffer
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a cancellable async byte-stream path for `AsyncDicomReader` so callers can parse metadata from an async source and stop before reading Pixel Data.
- Preserves existing ArrayBuffer/manual stream behavior while adding `readFileFromAsyncStream`, `shouldStop`, `stopInfo`, bounded read-ahead controls, and async `stopOnGreaterTag` support.
- Supports Node streams, browser/Web `ReadableStream`s, and generic async iterables without adding Node-only production imports.
- Normalizes parser `untilTag` options across sync and async readers so clean, lowercase, and punctuated tag forms behave consistently; invalid explicit tags fail fast.
- Fixes Node 24 fixture reads in tests by slicing Node `Buffer` backing stores to exact file bytes.

## Review guide

- Review `src/BufferStream.js` for the stream adapter/cancellation behavior:
  - Node streams use `destroy()` unless `destroyOnAbort: false` leaves ownership with the caller.
  - Web streams use `reader.cancel()` and release reader locks.
  - Generic async iterables attempt `iterator.return()` but are not awaited by default to avoid hangs.
  - Upstream source failures are preserved; only errors matching the pump-created abort reason are treated as intentional aborts.
- Review `src/AsyncDicomReader.js` for parser lifecycle behavior:
  - `readFileFromAsyncStream()` owns stream cleanup for the convenience path.
  - `stopInfo` distinguishes tag start, parser stop offset, value offset, and buffered size.
  - `stopOnGreaterTag` is scoped to the current dataset level and disabled for recursive sequence item reads.
- Review `src/DicomMetaDictionary.js` and `src/DicomMessage.js` to confirm parser option normalization is shared while public tag helper compatibility is preserved.
- Review tests in `test/readBufferStream.test.js`, `test/async-data.test.js`, `test/data-options.test.js`, and `test/DicomMetaDictionary.test.js` for the behavior contract and edge cases.

## Safety and risks

- This is additive and keeps existing `DicomMessage.readFile`, `reader.stream.addBuffer()`, and `fromAsyncStream()` usage working.
- Node/Web streams can only stop between delivered chunks. Callers needing strict no-pixel-byte buffering should choose source chunk/range sizes accordingly.
- Generic async iterables are cooperative. If a source has a pending `next()` that never resolves, caller-level cancellation may still be required; callers can opt into waiting with `streamOptions.awaitAbort: true`.
- `stopOnGreaterTag` relies on DICOM’s sorted Data Element invariant within each individual dataset/item.
- Deflated transfer syntax behavior is unchanged; this PR does not add async deflate support.

## Test plan

- [x] `pnpm exec jest --testTimeout 60000 --runTestsByPath test/readBufferStream.test.js test/async-data.test.js`
- [x] `pnpm exec jest --testTimeout 60000 --runTestsByPath test/DicomMetaDictionary.test.js test/data-options.test.js test/async-data.test.js`
- [x] `pnpm exec prettier --check src/BufferStream.js src/AsyncDicomReader.js test/readBufferStream.test.js test/async-data.test.js`
- [x] `pnpm exec eslint src/BufferStream.js src/AsyncDicomReader.js test/readBufferStream.test.js test/async-data.test.js`
- [x] `pnpm exec prettier --check src/DicomMetaDictionary.js src/DicomMessage.js src/AsyncDicomReader.js test/DicomMetaDictionary.test.js test/data-options.test.js test/async-data.test.js`
- [x] `pnpm exec eslint src/DicomMetaDictionary.js src/DicomMessage.js src/AsyncDicomReader.js test/DicomMetaDictionary.test.js test/data-options.test.js test/async-data.test.js`
- [x] `pnpm exec prettier --check test/testUtils.js test/anonymizer.test.js test/data.test.js`
- [x] `pnpm exec eslint test/testUtils.js test/anonymizer.test.js test/data.test.js`
- [x] `pnpm test`
- [x] `npx -p node@24 -c "node node_modules/jest/bin/jest.js --testTimeout 60000 ."`

## CI

- [x] lint-and-format
- [x] test (Node 22)
- [x] test (Node 24)
- [x] build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4773b57-f3b7-4008-8a46-93e83691208e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4773b57-f3b7-4008-8a46-93e83691208e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

