### PR TITLE
Harden async stream lifecycle handling

### DIFF
--- a/docs/AsyncDicomReader-skill.md
+++ b/docs/AsyncDicomReader-skill.md
@@ -116,12 +116,19 @@ const source = fs.createReadStream("image.dcm");
 
 const result = await reader.readFileFromAsyncStream(source, {
     untilTag: TagHex.PixelData,
-    includeUntilTagValue: false
+    includeUntilTagValue: false,
+    streamOptions: {
+        readAheadHighWaterMark: 64 * 1024
+    }
 });
 
 console.log(result.dict);
 console.log(result.stopInfo);
 ```
+
+`readAheadHighWaterMark` applies between source chunks. A single incoming
+chunk is added atomically, so retained bytes may exceed the mark by up to one
+source chunk.
 
 The same API accepts a browser response body:
 

--- a/docs/AsyncDicomReader-skill.md
+++ b/docs/AsyncDicomReader-skill.md
@@ -146,15 +146,17 @@ such as a STOW handler, can reject the read with its own error:
 
 ```javascript
 const readPromise = reader.readFileFromAsyncStream(source, options);
-
-try {
-    await processIncomingRequest();
-} catch (error) {
+const processingPromise = processIncomingRequest().catch(error => {
     reader.pump.abort(error);
-}
+    throw error;
+});
 
-await readPromise; // rejects with the external error
+await Promise.all([readPromise, processingPromise]);
 ```
+
+`pump.abort(error)` rejects a read that is still pending. It cannot change the
+state of a read promise that has already fulfilled, so the processing promise
+must also be awaited as shown above.
 
 Generic async iterables remain supported by the lower-level
 `reader.stream.fromAsyncStream()` API. They are not accepted by
@@ -465,6 +467,20 @@ Reads the entire DICOM file including meta information and dataset.
 
 **Returns:** `Promise<AsyncDicomReader>` - The reader instance
 
+#### `async readFileFromAsyncStream(stream, options)`
+Reads a DICOM file from a cancellable Node stream or browser
+`ReadableStream`. The source is stopped after parsing completes or reaches an
+early-stop condition.
+
+**Options:**
+- All `readFile()` options
+- `streamOptions.readAheadHighWaterMark` (number): Pause source reads between
+  chunks when unread bytes reach this threshold
+- `readerOptions` (Object, static factory only): Options for the reader
+  constructor
+
+**Returns:** `Promise<AsyncDicomReader>` - The reader instance
+
 #### `async readMeta(options)`
 Reads only the file meta information (Group 0x0002).
 
@@ -510,6 +526,10 @@ Reads a single tag header (tag, VR, length).
 - `dict` (Object): Dataset dictionary
 - `stream` (ReadBufferStream): Underlying buffer stream
 - `listener` (DicomMetadataListener): Current listener instance
+- `pump` (Object): Active stream handle exposing `abort(error)`, `failure`,
+  and `finished`
+- `stopInfo` (Object): Early-stop reason, tag/value offsets, available bytes,
+  and loaded end offset
 
 ## Common Patterns
 
@@ -783,7 +803,6 @@ The AsyncDicomReader is marked as preliminary. Future versions may include:
 - Files without DICM preamble
 - Improved streaming for network sources
 - Progress callbacks
-- Cancelable operations
 - More robust error recovery
 
 ## References

--- a/docs/AsyncDicomReader-skill.md
+++ b/docs/AsyncDicomReader-skill.md
@@ -98,6 +98,62 @@ async function readWithCustomListener(arrayBuffer) {
 }
 ```
 
+### Reading Metadata from a Cancellable Stream
+
+`readFileFromAsyncStream()` accepts Node readable streams and browser
+`ReadableStream` sources. It owns the source lifecycle and stops the source
+when parsing completes or reaches an early-stop condition.
+
+```javascript
+import fs from "node:fs";
+import dcmjs from "dcmjs";
+
+const { AsyncDicomReader } = dcmjs.async;
+const { TagHex } = dcmjs.constants;
+
+const reader = new AsyncDicomReader();
+const source = fs.createReadStream("image.dcm");
+
+const result = await reader.readFileFromAsyncStream(source, {
+    untilTag: TagHex.PixelData,
+    includeUntilTagValue: false
+});
+
+console.log(result.dict);
+console.log(result.stopInfo);
+```
+
+The same API accepts a browser response body:
+
+```javascript
+const response = await fetch("/image.dcm");
+const reader = await AsyncDicomReader.readFileFromAsyncStream(response.body, {
+    untilTag: "7FE00010"
+});
+```
+
+The exposed pump distinguishes successful parser completion from external
+processing failure. The reader stops its source successfully after an
+`untilTag`, `stopOnGreaterTag`, or `shouldStop` match. An external workflow,
+such as a STOW handler, can reject the read with its own error:
+
+```javascript
+const readPromise = reader.readFileFromAsyncStream(source, options);
+
+try {
+    await processIncomingRequest();
+} catch (error) {
+    reader.pump.abort(error);
+}
+
+await readPromise; // rejects with the external error
+```
+
+Generic async iterables remain supported by the lower-level
+`reader.stream.fromAsyncStream()` API. They are not accepted by
+`readFileFromAsyncStream()` because the async iterator protocol does not
+guarantee that `return()` interrupts a pending `next()` call.
+
 ## Architecture
 
 ### Core Components

--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -313,6 +313,9 @@ export class AsyncDicomReader {
     async read(listener, options) {
         options = this.normalizeReadOptions(options);
         const untilOffset = options?.untilOffset || Number.MAX_SAFE_INTEGER;
+        const checksAfterTag =
+            options.includeUntilTagValue ||
+            typeof options.shouldStop === "function";
         this.listener = listener;
         const { stream } = this;
         await stream.ensureAvailable(12);
@@ -375,7 +378,10 @@ export class AsyncDicomReader {
             if (this.stopInfo) {
                 break;
             }
-            if (await this.shouldStopAfterTag(tagInfo, listener, options)) {
+            if (
+                checksAfterTag &&
+                (await this.shouldStopAfterTag(tagInfo, listener, options))
+            ) {
                 break;
             }
             await this.stream.ensureAvailable(12);
@@ -768,7 +774,6 @@ export class AsyncDicomReader {
             includeUntilTagValue: false
         }
     ) {
-        options = this.normalizeReadOptions(options);
         const { stream, syntax } = this;
         const { untilTag, includeUntilTagValue } = options;
         const implicit = syntax == IMPLICIT_LITTLE_ENDIAN;

--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -49,14 +49,14 @@ export class AsyncDicomReader {
 
     static async readFileFromAsyncStream(stream, options = {}) {
         const { readerOptions, ...readOptions } = options;
-        const reader = new AsyncDicomReader(readerOptions);
+        const reader = new this(readerOptions);
         return reader.readFileFromAsyncStream(stream, readOptions);
     }
 
     async readFileFromAsyncStream(stream, options = {}) {
         const { streamOptions: inputStreamOptions, ...readOptions } = options;
         const streamOptions = {
-            maxReadAhead: 1024,
+            readAheadHighWaterMark: 1024,
             ...inputStreamOptions,
             requireCancellation: true
         };
@@ -64,6 +64,8 @@ export class AsyncDicomReader {
         const pump = this.stream.pumpAsyncStream(stream, streamOptions);
         this.pump = {
             abort: pump.abort,
+            cancellable: pump.cancellable,
+            failure: pump.failure,
             finished: pump.finished,
             get aborted() {
                 return pump.aborted;
@@ -72,15 +74,10 @@ export class AsyncDicomReader {
                 return pump.reason;
             }
         };
-        const pumpFailure = pump.finished.then(
-            () => new Promise(() => {}),
-            error => Promise.reject(error)
-        );
-
         try {
             const result = await Promise.race([
                 this.readFile(readOptions),
-                pumpFailure
+                pump.failure
             ]);
             pump.stop();
             await pump.finished;
@@ -271,7 +268,7 @@ export class AsyncDicomReader {
         const { stream } = this;
         await stream.ensureAvailable(12);
         const { offset: metaStartPos } = stream;
-        const el = this.readTagHeader();
+        const el = this.readTagHeader(undefined, true);
         if (el.tag !== TagHex.FileMetaInformationGroupLength) {
             // meta length tag is missing
             if (!options?.ignoreErrors) {
@@ -328,7 +325,7 @@ export class AsyncDicomReader {
             // Consume before reading the tag so that data before the
             // current tag can be cleared.
             stream.consume();
-            const tagInfo = this.readTagHeader(options);
+            const tagInfo = this.readTagHeader(options, true);
 
             if (tagInfo.isPastUntilTag) {
                 stream.offset = tagInfo.tagStartOffset;
@@ -423,7 +420,8 @@ export class AsyncDicomReader {
             valueOffset: tagInfo.valueOffset,
             valueLength: tagInfo.length,
             stopOffset: this.stream.offset,
-            bufferedSize: this.stream.size
+            availableBytes: this.stream.available,
+            loadedEndOffset: this.stream.endOffset
         };
         return this.stopInfo;
     }
@@ -441,7 +439,7 @@ export class AsyncDicomReader {
             (await stream.ensureAvailable(12))
         ) {
             readLog.debug("readSequence loop", stream.offset, endOffset);
-            const tagInfo = this.readTagHeader();
+            const tagInfo = this.readTagHeader(undefined, true);
             const { tag } = tagInfo;
             if (tag === TagHex.Item) {
                 listener.startObject();
@@ -548,7 +546,7 @@ export class AsyncDicomReader {
             readLog.debug("readCompressed frame loop", frameNumber);
             stream.consume();
             await stream.ensureAvailable();
-            const frameTag = this.readTagHeader();
+            const frameTag = this.readTagHeader(undefined, true);
             if (frameTag.tag === TagHex.SequenceDelimitationEnd) {
                 if (lastFrame) {
                     // Always deliver frames as arrays, using streaming splitFrame
@@ -578,7 +576,7 @@ export class AsyncDicomReader {
     }
 
     async readOffsets() {
-        const tagInfo = this.readTagHeader();
+        const tagInfo = this.readTagHeader(undefined, true);
         if (tagInfo.tag !== TagHex.Item) {
             throw new Error(`Offsets tag is missing: ${tagInfo.tag}`);
         }
@@ -772,8 +770,12 @@ export class AsyncDicomReader {
         options = {
             untilTag: null,
             includeUntilTagValue: false
-        }
+        },
+        optionsAreNormalized = false
     ) {
+        if (!optionsAreNormalized) {
+            options = this.normalizeReadOptions(options);
+        }
         const { stream, syntax } = this;
         const { untilTag, includeUntilTagValue } = options;
         const implicit = syntax == IMPLICIT_LITTLE_ENDIAN;

--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -328,7 +328,6 @@ export class AsyncDicomReader {
             const tagInfo = this.readTagHeader(options, true);
 
             if (tagInfo.isPastUntilTag) {
-                stream.offset = tagInfo.tagStartOffset;
                 this.setStopInfo("stopOnGreaterTag", tagInfo);
                 break;
             }
@@ -800,6 +799,7 @@ export class AsyncDicomReader {
         }
 
         if (untilTag && options.stopOnGreaterTag && tag > untilTag) {
+            stream.increment(tagStartOffset - stream.offset);
             return {
                 tag,
                 tagObj,
@@ -807,7 +807,7 @@ export class AsyncDicomReader {
                 values: 0,
                 isPastUntilTag: true,
                 tagStartOffset,
-                stopOffset: tagStartOffset
+                stopOffset: stream.offset
             };
         }
 

--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -19,6 +19,7 @@ import { DicomMetadataListener } from "./utilities/DicomMetadataListener.js";
 import { log } from "./log.js";
 
 const readLog = log.getLogger("AsyncDicomReader");
+const NORMALIZED_READ_OPTIONS = Symbol("normalizedReadOptions");
 
 /**
  * This is an asynchronous binary DICOM reader.
@@ -31,6 +32,7 @@ const readLog = log.getLogger("AsyncDicomReader");
 export class AsyncDicomReader {
     syntax = EXPLICIT_LITTLE_ENDIAN;
     stopInfo = null;
+    pump = null;
 
     constructor(options = {}) {
         this.isLittleEndian = options?.isLittleEndian;
@@ -52,59 +54,45 @@ export class AsyncDicomReader {
     }
 
     async readFileFromAsyncStream(stream, options = {}) {
-        const {
-            streamOptions: inputStreamOptions,
-            stopStreamOnComplete = true,
-            ...readOptions
-        } = options;
+        const { streamOptions: inputStreamOptions, ...readOptions } = options;
         const streamOptions = {
             maxReadAhead: 1024,
-            ...inputStreamOptions
+            ...inputStreamOptions,
+            requireCancellation: true
         };
 
         const pump = this.stream.pumpAsyncStream(stream, streamOptions);
-        const awaitAbort = this.shouldAwaitStreamAbort(stream, streamOptions);
+        this.pump = {
+            abort: pump.abort,
+            finished: pump.finished,
+            get aborted() {
+                return pump.aborted;
+            },
+            get reason() {
+                return pump.reason;
+            }
+        };
+        const pumpFailure = pump.finished.then(
+            () => new Promise(() => {}),
+            error => Promise.reject(error)
+        );
 
         try {
-            const result = await this.readFile(readOptions);
-            if (stopStreamOnComplete) {
-                pump.abort();
-                await this.settlePumpAfterAbort(pump, awaitAbort);
-            }
+            const result = await Promise.race([
+                this.readFile(readOptions),
+                pumpFailure
+            ]);
+            pump.stop();
+            await pump.finished;
             return result;
         } catch (error) {
             pump.abort(error);
-            await this.settlePumpAfterAbort(pump, awaitAbort);
-            throw error;
-        }
-    }
-
-    shouldAwaitStreamAbort(stream, streamOptions) {
-        if (streamOptions.awaitAbort !== undefined) {
-            return streamOptions.awaitAbort;
-        }
-        return (
-            streamOptions.cancelOnAbort !== false &&
-            (typeof stream.destroy === "function" ||
-                typeof stream.getReader === "function")
-        );
-    }
-
-    async settlePumpAfterAbort(pump, shouldAwait) {
-        const finished = pump.finished.catch(error => {
-            if (
-                pump.aborted &&
-                ReadBufferStream.isAbortError(error, pump.reason)
-            ) {
-                return;
+            try {
+                await pump.finished;
+            } catch {
+                // Preserve the parsing, source, or externally supplied error.
             }
             throw error;
-        });
-
-        if (shouldAwait) {
-            await finished;
-        } else {
-            finished.catch(() => {});
         }
     }
 
@@ -214,6 +202,7 @@ export class AsyncDicomReader {
     }
 
     async readFile(options = undefined) {
+        options = this.normalizeReadOptions(options);
         this.stopInfo = null;
         const hasPreamble = await this.readPreamble();
         if (hasPreamble === AsyncDicomReader.PART10_NO_PREAMBLE) {
@@ -322,6 +311,7 @@ export class AsyncDicomReader {
     }
 
     async read(listener, options) {
+        options = this.normalizeReadOptions(options);
         const untilOffset = options?.untilOffset || Number.MAX_SAFE_INTEGER;
         this.listener = listener;
         const { stream } = this;
@@ -394,6 +384,11 @@ export class AsyncDicomReader {
     }
 
     async shouldStopAfterTag(tagInfo, listener, options) {
+        if (options?.includeUntilTagValue && options.untilTag === tagInfo.tag) {
+            this.setStopInfo("untilTag", tagInfo);
+            return true;
+        }
+
         const { shouldStop } = options || {};
         if (typeof shouldStop !== "function") {
             return false;
@@ -459,6 +454,7 @@ export class AsyncDicomReader {
                     ...options,
                     untilTag: null,
                     includeUntilTagValue: false,
+                    shouldStop: undefined,
                     stopOnGreaterTag: false,
                     untilOffset: itemUntilOffset
                 };
@@ -746,13 +742,21 @@ export class AsyncDicomReader {
     }
 
     normalizeReadOptions(options = {}) {
-        return {
+        options ||= {};
+        if (options[NORMALIZED_READ_OPTIONS]) {
+            return options;
+        }
+        const normalizedOptions = {
             ...options,
             untilTag: DicomMetaDictionary.normalizeTagOption(
                 options.untilTag,
                 "untilTag"
             )
         };
+        Object.defineProperty(normalizedOptions, NORMALIZED_READ_OPTIONS, {
+            value: true
+        });
+        return normalizedOptions;
     }
 
     /**

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -266,9 +266,8 @@ export class BufferStream {
 
     readUint16Array(length) {
         var sixlen = length / 2,
-            arr = new Uint16Array(sixlen),
-            i = 0;
-        while (i++ < sixlen) {
+            arr = new Uint16Array(sixlen);
+        for (let i = 0; i < sixlen; i++) {
             arr[i] = this.view.getUint16(this.offset, this.isLittleEndian);
             this.increment(2);
         }
@@ -361,7 +360,7 @@ export class BufferStream {
             new Uint8Array(stream.slice(stream.startOffset, stream.size)),
             this.offset
         );
-        this.offset += stream.size;
+        this.increment(stream.size);
         this.size = this.offset;
         this.endOffset = this.size;
         return this.view.availableSize;
@@ -374,6 +373,9 @@ export class BufferStream {
         }
         if (this.readAheadListeners.length > 0) {
             this.notifyReadAheadListeners();
+        }
+        if (step < 0 && this.availableListeners.length > 0) {
+            this.notifyAvailableListeners();
         }
         return step;
     }
@@ -390,12 +392,15 @@ export class BufferStream {
      * the source without requiring callers to read the rest of it first.
      */
     pumpAsyncStream(stream, options = {}) {
-        const source = BufferStream.asyncSourceFromStream(stream);
-        if (options.requireCancellation && !source.cancellable) {
+        if (
+            options.requireCancellation &&
+            !BufferStream.isCancellableAsyncStream(stream)
+        ) {
             throw new TypeError(
                 "Cancellable stream must be a Node stream or ReadableStream"
             );
         }
+        const source = BufferStream.asyncSourceFromStream(stream);
         let rejectFailure;
         let resolveStop;
         const failure = new Promise((_resolve, reject) => {
@@ -408,44 +413,54 @@ export class BufferStream {
         const state = {
             cancelRequested: false,
             cancelPromise: Promise.resolve(),
+            finalizing: false,
             failure: undefined,
+            hasFailure: false,
             settled: false,
             stopSignal,
             stopped: false
         };
 
         const reportFailure = error => {
-            if (state.failure) {
+            if (state.hasFailure) {
                 return;
             }
-            state.failure = error;
-            rejectFailure(error);
-            this.setFailed(error);
+            const failure = BufferStream.toError(error, "Async stream failed");
+            state.failure = failure;
+            state.hasFailure = true;
+            rejectFailure(failure);
+            this.setFailed(failure);
         };
 
         const cancel = error => {
-            if (error) {
+            if (error !== undefined) {
                 reportFailure(error);
             }
-            if (state.cancelRequested || state.settled) {
+            if (state.cancelRequested || state.finalizing || state.settled) {
                 return;
             }
             state.cancelRequested = true;
             state.stopped = true;
             resolveStop();
-            const cancelSource = error ? source.abort : source.stop;
-            const reason = error ?? BufferStream.createStopReason();
+            const cancelSource =
+                error !== undefined ? source.abort : source.stop;
+            const reason =
+                error !== undefined
+                    ? state.failure
+                    : BufferStream.createStopReason();
             state.cancelPromise = BufferStream.cancelSource(
                 cancelSource,
                 reason
             );
-            if (!error) {
+            if (error === undefined) {
                 this.setComplete();
             }
         };
         state.cancel = cancel;
         state.reportFailure = reportFailure;
-        state.removeErrorListener = source.onError?.(cancel);
+        state.removeErrorListener = source.onError?.(error =>
+            cancel(BufferStream.toError(error, "Async source failed"))
+        );
 
         const finished = this._pumpAsyncStream(source, state, options);
         finished.catch(() => {});
@@ -457,7 +472,7 @@ export class BufferStream {
             finished,
             stop: () => cancel(),
             get aborted() {
-                return !!state.failure;
+                return state.hasFailure;
             },
             get reason() {
                 return state.failure;
@@ -469,6 +484,7 @@ export class BufferStream {
     }
 
     async _pumpAsyncStream(source, state, options) {
+        let reachedEnd = false;
         try {
             while (!state.stopped) {
                 const next = Promise.resolve()
@@ -480,6 +496,7 @@ export class BufferStream {
                 }
                 const { done, value } = nextResult.result;
                 if (done) {
+                    reachedEnd = true;
                     break;
                 }
                 this.addBuffer(BufferStream.arrayBufferFromChunk(value));
@@ -491,12 +508,24 @@ export class BufferStream {
         } catch (error) {
             const expectedStopError =
                 state.stopped &&
-                !state.failure &&
+                !state.hasFailure &&
                 source.isExpectedStopError?.(error);
-            if (!expectedStopError && error !== state.failure) {
-                state.cancel(error);
+            const isReportedFailure =
+                state.hasFailure && error === state.failure;
+            if (!expectedStopError && !isReportedFailure) {
+                state.cancel(
+                    BufferStream.toError(error, "Async source failed")
+                );
             }
         } finally {
+            if (
+                reachedEnd &&
+                options.requireCancellation &&
+                !state.cancelRequested
+            ) {
+                state.cancel();
+            }
+            state.finalizing = true;
             try {
                 await state.cancelPromise;
             } catch (error) {
@@ -509,13 +538,13 @@ export class BufferStream {
                 }
                 state.removeErrorListener?.();
                 state.settled = true;
-                if (!state.failure) {
+                if (!state.hasFailure) {
                     this.setComplete();
                 }
             }
         }
 
-        if (state.failure) {
+        if (state.hasFailure) {
             throw state.failure;
         }
     }
@@ -524,11 +553,11 @@ export class BufferStream {
         return new Error("BufferStream stopped");
     }
 
-    static toError(error) {
+    static toError(error, fallbackMessage = "BufferStream aborted") {
         if (error instanceof Error) {
             return error;
         }
-        return new Error(error ? String(error) : "BufferStream aborted");
+        return new Error(error ? String(error) : fallbackMessage);
     }
 
     static cancelSource(cancelSource, reason) {
@@ -539,9 +568,23 @@ export class BufferStream {
         }
     }
 
+    static isCancellableAsyncStream(stream) {
+        if (typeof stream?.getReader === "function") {
+            return true;
+        }
+        return (
+            typeof stream?.[Symbol.asyncIterator] === "function" &&
+            typeof stream.destroy === "function" &&
+            typeof stream.once === "function" &&
+            typeof stream.on === "function" &&
+            typeof stream.off === "function"
+        );
+    }
+
     static destroyNodeStream(stream, reason) {
         if (
             typeof stream.once !== "function" ||
+            typeof stream.on !== "function" ||
             typeof stream.off !== "function"
         ) {
             stream.destroy(reason);
@@ -611,6 +654,7 @@ export class BufferStream {
             const hasDestroy = typeof stream.destroy === "function";
             const canObserveClose =
                 typeof stream.once === "function" &&
+                typeof stream.on === "function" &&
                 typeof stream.off === "function";
             return {
                 cancellable: hasDestroy && canObserveClose,
@@ -759,7 +803,7 @@ export class BufferStream {
     }
 
     reset() {
-        this.offset = 0;
+        this.increment(-this.offset);
         return this;
     }
 
@@ -817,7 +861,7 @@ export class ReadBufferStream extends BufferStream {
     }
 
     reset() {
-        this.offset = this.startOffset;
+        this.increment(this.startOffset - this.offset);
         return this;
     }
 

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -372,7 +372,6 @@ export class BufferStream {
         if (this.offset > this.size) {
             this.size = this.offset;
         }
-        this.notifyReadAheadListeners();
         return step;
     }
 
@@ -612,6 +611,7 @@ export class BufferStream {
      * The default offset is the current position, so everything already read.
      */
     consume(offset = this.offset) {
+        this.notifyReadAheadListeners();
         if (!this.clearBuffers) {
             return;
         }

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -270,7 +270,7 @@ export class BufferStream {
             i = 0;
         while (i++ < sixlen) {
             arr[i] = this.view.getUint16(this.offset, this.isLittleEndian);
-            this.offset += 2;
+            this.increment(2);
         }
         return arr;
     }
@@ -372,6 +372,9 @@ export class BufferStream {
         if (this.offset > this.size) {
             this.size = this.offset;
         }
+        if (this.readAheadListeners.length > 0) {
+            this.notifyReadAheadListeners();
+        }
         return step;
     }
 
@@ -393,37 +396,64 @@ export class BufferStream {
                 "Cancellable stream must be a Node stream or ReadableStream"
             );
         }
+        let rejectFailure;
+        let resolveStop;
+        const failure = new Promise((_resolve, reject) => {
+            rejectFailure = reject;
+        });
+        failure.catch(() => {});
+        const stopSignal = new Promise(resolve => {
+            resolveStop = resolve;
+        });
         const state = {
+            cancelRequested: false,
             cancelPromise: Promise.resolve(),
             failure: undefined,
             settled: false,
+            stopSignal,
             stopped: false
         };
 
-        const cancel = failure => {
-            if (state.stopped || state.settled) {
+        const reportFailure = error => {
+            if (state.failure) {
                 return;
             }
-            state.failure = failure;
+            state.failure = error;
+            rejectFailure(error);
+            this.setFailed(error);
+        };
+
+        const cancel = error => {
+            if (error) {
+                reportFailure(error);
+            }
+            if (state.cancelRequested || state.settled) {
+                return;
+            }
+            state.cancelRequested = true;
             state.stopped = true;
-            const cancelSource = failure ? source.abort : source.stop;
-            const reason = failure ?? BufferStream.createStopReason();
+            resolveStop();
+            const cancelSource = error ? source.abort : source.stop;
+            const reason = error ?? BufferStream.createStopReason();
             state.cancelPromise = BufferStream.cancelSource(
                 cancelSource,
                 reason
             );
-            if (failure) {
-                this.setFailed(failure);
-            } else {
+            if (!error) {
                 this.setComplete();
             }
         };
+        state.cancel = cancel;
+        state.reportFailure = reportFailure;
+        state.removeErrorListener = source.onError?.(cancel);
 
         const finished = this._pumpAsyncStream(source, state, options);
         finished.catch(() => {});
 
         return {
             abort: error => cancel(BufferStream.toError(error)),
+            cancellable: source.cancellable,
+            failure,
             finished,
             stop: () => cancel(),
             get aborted() {
@@ -439,34 +469,47 @@ export class BufferStream {
     }
 
     async _pumpAsyncStream(source, state, options) {
-        let cancellationError;
-        let sourceError;
         try {
             while (!state.stopped) {
-                const { done, value } = await source.next();
-                if (done || state.stopped) {
+                const next = Promise.resolve()
+                    .then(() => source.next())
+                    .then(result => ({ result }));
+                const nextResult = await Promise.race([next, state.stopSignal]);
+                if (!nextResult || state.stopped) {
+                    break;
+                }
+                const { done, value } = nextResult.result;
+                if (done) {
                     break;
                 }
                 this.addBuffer(BufferStream.arrayBufferFromChunk(value));
-                await this.waitForReadAhead(options.maxReadAhead, state);
+                await this.waitForReadAhead(
+                    options.readAheadHighWaterMark,
+                    state
+                );
             }
         } catch (error) {
-            if (error !== state.failure) {
-                sourceError = error;
+            const expectedStopError =
+                state.stopped &&
+                !state.failure &&
+                source.isExpectedStopError?.(error);
+            if (!expectedStopError && error !== state.failure) {
+                state.cancel(error);
             }
         } finally {
             try {
                 await state.cancelPromise;
             } catch (error) {
-                cancellationError = error;
+                state.reportFailure(error);
             } finally {
-                source.release?.();
+                try {
+                    source.release?.();
+                } catch (error) {
+                    state.reportFailure(error);
+                }
+                state.removeErrorListener?.();
                 state.settled = true;
-                const failure =
-                    state.failure || sourceError || cancellationError;
-                if (failure) {
-                    this.setFailed(failure);
-                } else {
+                if (!state.failure) {
                     this.setComplete();
                 }
             }
@@ -474,12 +517,6 @@ export class BufferStream {
 
         if (state.failure) {
             throw state.failure;
-        }
-        if (sourceError) {
-            throw sourceError;
-        }
-        if (cancellationError) {
-            throw cancellationError;
         }
     }
 
@@ -502,6 +539,61 @@ export class BufferStream {
         }
     }
 
+    static destroyNodeStream(stream, reason) {
+        if (
+            typeof stream.once !== "function" ||
+            typeof stream.off !== "function"
+        ) {
+            stream.destroy(reason);
+            return Promise.resolve();
+        }
+        if (stream.closed) {
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve, reject) => {
+            let destroyError;
+            let isSettled = false;
+            let waitTimer;
+            const cleanup = () => {
+                clearTimeout(waitTimer);
+                stream.off("close", onClose);
+                stream.off("error", onError);
+            };
+            const settle = () => {
+                if (isSettled) {
+                    return;
+                }
+                isSettled = true;
+                cleanup();
+                destroyError ? reject(destroyError) : resolve();
+            };
+            const onError = error => {
+                destroyError ||= error;
+            };
+            const onClose = () => settle();
+            const waitForClosed = () => {
+                if (stream.closed) {
+                    waitTimer = setTimeout(settle, 0);
+                } else {
+                    waitTimer = setTimeout(waitForClosed, 0);
+                }
+            };
+
+            stream.once("close", onClose);
+            stream.on("error", onError);
+            try {
+                stream.destroy(reason);
+                if (stream._readableState?.emitClose === false) {
+                    waitForClosed();
+                }
+            } catch (error) {
+                destroyError ||= error;
+                settle();
+            }
+        });
+    }
+
     static asyncSourceFromStream(stream) {
         if (typeof stream?.getReader === "function") {
             const reader = stream.getReader();
@@ -517,14 +609,33 @@ export class BufferStream {
         const iterator = stream?.[Symbol.asyncIterator]?.();
         if (iterator) {
             const hasDestroy = typeof stream.destroy === "function";
-            const canStop = typeof iterator.return === "function";
+            const canObserveClose =
+                typeof stream.once === "function" &&
+                typeof stream.off === "function";
             return {
-                cancellable: hasDestroy && canStop,
+                cancellable: hasDestroy && canObserveClose,
                 next: () => iterator.next(),
                 abort: hasDestroy
-                    ? reason => stream.destroy(reason)
+                    ? reason => BufferStream.destroyNodeStream(stream, reason)
                     : reason => iterator.return?.(reason),
-                stop: canStop ? () => iterator.return() : undefined
+                stop: hasDestroy
+                    ? () => BufferStream.destroyNodeStream(stream)
+                    : () => iterator.return?.(),
+                onError:
+                    typeof stream.on === "function" &&
+                    typeof stream.off === "function"
+                        ? handler => {
+                              stream.on("error", handler);
+                              return () => stream.off("error", handler);
+                          }
+                        : undefined,
+                isExpectedStopError: hasDestroy
+                    ? error =>
+                          error?.name === "AbortError" ||
+                          error?.code === "ABORT_ERR" ||
+                          error?.code === "ERR_STREAM_PREMATURE_CLOSE" ||
+                          error?.message === "Premature close"
+                    : undefined
             };
         }
 
@@ -545,25 +656,28 @@ export class BufferStream {
         }
         throw new TypeError("Async stream chunks must be ArrayBuffer views");
     }
-    async waitForReadAhead(maxReadAhead, state) {
-        if (typeof maxReadAhead !== "number") {
+    async waitForReadAhead(readAheadHighWaterMark, state) {
+        if (typeof readAheadHighWaterMark !== "number") {
             return;
         }
 
-        while (!state.stopped && this.isPastReadAheadLimit(maxReadAhead)) {
+        while (
+            !state.stopped &&
+            this.isPastReadAheadLimit(readAheadHighWaterMark)
+        ) {
             await new Promise(resolve => {
                 this.readAheadListeners.push(resolve);
             });
         }
     }
 
-    isPastReadAheadLimit(maxReadAhead) {
-        const limit = this.readAheadLimit(maxReadAhead);
+    isPastReadAheadLimit(readAheadHighWaterMark) {
+        const limit = this.readAheadLimit(readAheadHighWaterMark);
         return limit === 0 ? this.available > 0 : this.available >= limit;
     }
 
-    readAheadLimit(maxReadAhead) {
-        return Math.max(0, maxReadAhead, this.requestedAvailable);
+    readAheadLimit(readAheadHighWaterMark) {
+        return Math.max(0, readAheadHighWaterMark, this.requestedAvailable);
     }
 
     /**
@@ -611,7 +725,6 @@ export class BufferStream {
      * The default offset is the current position, so everything already read.
      */
     consume(offset = this.offset) {
-        this.notifyReadAheadListeners();
         if (!this.clearBuffers) {
             return;
         }
@@ -655,7 +768,7 @@ export class BufferStream {
     }
 
     toEnd() {
-        this.offset = this.view.byteLength;
+        this.increment(this.view.byteLength - this.offset);
     }
 
     /**
@@ -713,7 +826,7 @@ export class ReadBufferStream extends BufferStream {
     }
 
     toEnd() {
-        this.offset = this.endOffset;
+        this.increment(this.endOffset - this.offset);
     }
 
     writeUint8(value) {

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -16,6 +16,7 @@ export class BufferStream {
 
     /** Indicates if this buffer stream is complete/has finished being created */
     isComplete = false;
+    failure = null;
 
     /** A flag to set to indicate to clear buffers as they get consumed */
     clearBuffers = false;
@@ -37,6 +38,11 @@ export class BufferStream {
         this.notifyReadAheadListeners();
     }
 
+    setFailed(error) {
+        this.failure = error;
+        this.setComplete();
+    }
+
     /**
      * Indicates if the value length is currently available in the already
      * read/defined portion of the stream.
@@ -56,11 +62,18 @@ export class BufferStream {
      * EOF.  By default waits for at least 1k to be available.
      */
     ensureAvailable(bytes = 1024) {
+        if (this.failure) {
+            return Promise.reject(this.failure);
+        }
         if (!this.isAvailable(bytes)) {
             this.requestedAvailable = Math.max(this.requestedAvailable, bytes);
             this.notifyReadAheadListeners();
-            return new Promise(resolve => {
+            return new Promise((resolve, reject) => {
                 const recheckAvailable = () => {
+                    if (this.failure) {
+                        reject(this.failure);
+                        return;
+                    }
                     if (this.isAvailable(bytes)) {
                         if (this.requestedAvailable <= bytes) {
                             this.requestedAvailable = 0;
@@ -375,92 +388,118 @@ export class BufferStream {
      * the source without requiring callers to read the rest of it first.
      */
     pumpAsyncStream(stream, options = {}) {
+        const source = BufferStream.asyncSourceFromStream(stream);
+        if (options.requireCancellation && !source.cancellable) {
+            throw new TypeError(
+                "Cancellable stream must be a Node stream or ReadableStream"
+            );
+        }
         const state = {
-            aborted: false,
-            reason: undefined
+            cancelPromise: Promise.resolve(),
+            failure: undefined,
+            settled: false,
+            stopped: false
         };
 
-        const abort = reason => {
-            if (state.aborted) {
+        const cancel = failure => {
+            if (state.stopped || state.settled) {
                 return;
             }
-            const abortReason = reason ?? BufferStream.createAbortReason();
-            state.aborted = true;
-            state.reason = abortReason;
-            if (options.cancelOnAbort !== false) {
-                if (
-                    options.destroyOnAbort !== false &&
-                    typeof stream.destroy === "function"
-                ) {
-                    stream.destroy(abortReason);
-                } else if (typeof stream.destroy !== "function") {
-                    state.cancelPromise = BufferStream.cancelSource(
-                        state.cancelSource,
-                        abortReason
-                    );
-                } else {
-                    state.cancelPromise = Promise.resolve();
-                }
+            state.failure = failure;
+            state.stopped = true;
+            const cancelSource = failure ? source.abort : source.stop;
+            const reason = failure ?? BufferStream.createStopReason();
+            state.cancelPromise = BufferStream.cancelSource(
+                cancelSource,
+                reason
+            );
+            if (failure) {
+                this.setFailed(failure);
+            } else {
+                this.setComplete();
             }
-            this.setComplete();
-            this.notifyReadAheadListeners();
         };
 
-        const finished = this._pumpAsyncStream(stream, state, options);
+        const finished = this._pumpAsyncStream(source, state, options);
+        finished.catch(() => {});
 
         return {
-            abort,
+            abort: error => cancel(BufferStream.toError(error)),
             finished,
+            stop: () => cancel(),
             get aborted() {
-                return state.aborted;
+                return !!state.failure;
             },
             get reason() {
-                return state.reason;
+                return state.failure;
+            },
+            get stopped() {
+                return state.stopped;
             }
         };
     }
 
-    async _pumpAsyncStream(stream, state, options) {
-        const source = BufferStream.asyncSourceFromStream(stream);
-        state.cancelSource = source.cancel;
+    async _pumpAsyncStream(source, state, options) {
+        let cancellationError;
+        let sourceError;
         try {
-            while (!state.aborted) {
+            while (!state.stopped) {
                 const { done, value } = await source.next();
-                if (done || state.aborted) {
+                if (done || state.stopped) {
                     break;
                 }
                 this.addBuffer(BufferStream.arrayBufferFromChunk(value));
                 await this.waitForReadAhead(options.maxReadAhead, state);
             }
         } catch (error) {
-            if (
-                state.aborted &&
-                BufferStream.isAbortError(error, state.reason)
-            ) {
-                return;
+            if (error !== state.failure) {
+                sourceError = error;
             }
-            throw error;
         } finally {
-            await state.cancelPromise;
-            source.release?.();
-            state.cancelSource = null;
-            this.setComplete();
+            try {
+                await state.cancelPromise;
+            } catch (error) {
+                cancellationError = error;
+            } finally {
+                source.release?.();
+                state.settled = true;
+                const failure =
+                    state.failure || sourceError || cancellationError;
+                if (failure) {
+                    this.setFailed(failure);
+                } else {
+                    this.setComplete();
+                }
+            }
+        }
+
+        if (state.failure) {
+            throw state.failure;
+        }
+        if (sourceError) {
+            throw sourceError;
+        }
+        if (cancellationError) {
+            throw cancellationError;
         }
     }
 
-    static isAbortError(error, reason) {
-        return error === reason;
+    static createStopReason() {
+        return new Error("BufferStream stopped");
     }
 
-    static createAbortReason() {
-        return new Error("BufferStream aborted");
+    static toError(error) {
+        if (error instanceof Error) {
+            return error;
+        }
+        return new Error(error ? String(error) : "BufferStream aborted");
     }
 
     static cancelSource(cancelSource, reason) {
         try {
-            return Promise.resolve(cancelSource?.(reason)).catch(() => {});
-        } catch {
-            return Promise.resolve();
+            return Promise.resolve(cancelSource?.(reason));
+        } catch (error) {
+            return Promise.reject(error);
         }
     }
 
@@ -468,17 +507,25 @@ export class BufferStream {
         if (typeof stream?.getReader === "function") {
             const reader = stream.getReader();
             return {
+                cancellable: true,
                 next: () => reader.read(),
-                cancel: reason => reader.cancel(reason),
+                abort: reason => reader.cancel(reason),
+                stop: reason => reader.cancel(reason),
                 release: () => reader.releaseLock()
             };
         }
 
         const iterator = stream?.[Symbol.asyncIterator]?.();
         if (iterator) {
+            const hasDestroy = typeof stream.destroy === "function";
+            const canStop = typeof iterator.return === "function";
             return {
+                cancellable: hasDestroy && canStop,
                 next: () => iterator.next(),
-                cancel: reason => iterator.return?.(reason)
+                abort: hasDestroy
+                    ? reason => stream.destroy(reason)
+                    : reason => iterator.return?.(reason),
+                stop: canStop ? () => iterator.return() : undefined
             };
         }
 
@@ -504,7 +551,7 @@ export class BufferStream {
             return;
         }
 
-        while (!state.aborted && this.isPastReadAheadLimit(maxReadAhead)) {
+        while (!state.stopped && this.isPastReadAheadLimit(maxReadAhead)) {
             await new Promise(resolve => {
                 this.readAheadListeners.push(resolve);
             });
@@ -550,6 +597,9 @@ export class BufferStream {
     }
 
     notifyReadAheadListeners() {
+        if (this.readAheadListeners.length === 0) {
+            return;
+        }
         const existingListeners = [...this.readAheadListeners];
         this.readAheadListeners.splice(0, this.readAheadListeners.length);
         existingListeners.forEach(listener => listener());

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -18,6 +18,7 @@ import { deepEqual } from "./utilities/deepEqual";
 import { ValueRepresentation } from "./ValueRepresentation.js";
 
 export const singleVRs = ["SQ", "OF", "OW", "OB", "UN", "LT"];
+const NORMALIZED_READ_OPTIONS = Symbol("normalizedReadOptions");
 
 export class DicomMessage {
     static read(
@@ -214,13 +215,21 @@ export class DicomMessage {
     }
 
     static _normalizeReadOptions(options = {}) {
-        return {
+        options ||= {};
+        if (options[NORMALIZED_READ_OPTIONS]) {
+            return options;
+        }
+        const normalizedOptions = {
             ...options,
             untilTag: DicomMetaDictionary.normalizeTagOption(
                 options.untilTag,
                 "untilTag"
             )
         };
+        Object.defineProperty(normalizedOptions, NORMALIZED_READ_OPTIONS, {
+            value: true
+        });
+        return normalizedOptions;
     }
 
     static writeTagObject(stream, tagString, vr, values, syntax, writeOptions) {

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -43,10 +43,14 @@ export class DicomMessage {
         includeUntilTagValue = false
     ) {
         log.warn("DicomMessage.readTag to be deprecated after dcmjs 0.24.x");
-        return this._readTag(bufferStream, syntax, {
-            untilTag: untilTag,
-            includeUntilTagValue: includeUntilTagValue
-        });
+        return this._readTag(
+            bufferStream,
+            syntax,
+            this._normalizeReadOptions({
+                untilTag: untilTag,
+                includeUntilTagValue: includeUntilTagValue
+            })
+        );
     }
 
     static _read(
@@ -294,7 +298,6 @@ export class DicomMessage {
             includeUntilTagValue: false
         }
     ) {
-        options = DicomMessage._normalizeReadOptions(options);
         const { untilTag, includeUntilTagValue } = options;
         var implicit = syntax == IMPLICIT_LITTLE_ENDIAN ? true : false,
             isLittleEndian =

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -49,7 +49,8 @@ export class DicomMessage {
             this._normalizeReadOptions({
                 untilTag: untilTag,
                 includeUntilTagValue: includeUntilTagValue
-            })
+            }),
+            true
         );
     }
 
@@ -73,7 +74,8 @@ export class DicomMessage {
                 const readInfo = DicomMessage._readTag(
                     bufferStream,
                     syntax,
-                    options
+                    options,
+                    true
                 );
                 const cleanTagString = readInfo.tag.toCleanString();
                 if (untilTag && stopOnGreaterTag && cleanTagString > untilTag) {
@@ -170,7 +172,7 @@ export class DicomMessage {
         var metaStartPos = stream.offset;
 
         // read the first tag to check if it's the meta length tag
-        var el = DicomMessage._readTag(stream, useSyntax);
+        var el = DicomMessage._readTag(stream, useSyntax, undefined, true);
 
         var metaHeader = {};
         if (el.tag.cleanString !== TagHex.FileMetaInformationGroupLength) {
@@ -296,8 +298,12 @@ export class DicomMessage {
         options = {
             untilTag: null,
             includeUntilTagValue: false
-        }
+        },
+        optionsAreNormalized = false
     ) {
+        if (!optionsAreNormalized) {
+            options = DicomMessage._normalizeReadOptions(options);
+        }
         const { untilTag, includeUntilTagValue } = options;
         var implicit = syntax == IMPLICIT_LITTLE_ENDIAN ? true : false,
             isLittleEndian =

--- a/test/async-data.test.js
+++ b/test/async-data.test.js
@@ -55,14 +55,23 @@ describe("AsyncDicomReader", () => {
         await expect(
             reader.readFileFromAsyncStream(new ArrayBuffer(16))
         ).rejects.toThrow(
-            "Async stream must be an async iterable or ReadableStream"
+            "Cancellable stream must be a Node stream or ReadableStream"
         );
     });
 
     it("rejects non-cancellable async iterables.", async () => {
+        let iteratorAcquisitions = 0;
         const source = {
-            async *[Symbol.asyncIterator]() {
-                yield new Uint8Array([1, 2, 3]);
+            [Symbol.asyncIterator]() {
+                iteratorAcquisitions++;
+                return {
+                    next() {
+                        return Promise.resolve({
+                            done: false,
+                            value: new Uint8Array([1, 2, 3])
+                        });
+                    }
+                };
             }
         };
         const reader = new AsyncDicomReader();
@@ -70,6 +79,30 @@ describe("AsyncDicomReader", () => {
         await expect(reader.readFileFromAsyncStream(source)).rejects.toThrow(
             "Cancellable stream must be a Node stream or ReadableStream"
         );
+        expect(iteratorAcquisitions).toBe(0);
+    });
+
+    it("rejects Node-like sources missing error observation.", async () => {
+        let iteratorAcquisitions = 0;
+        const source = {
+            destroy() {},
+            off() {},
+            once() {},
+            [Symbol.asyncIterator]() {
+                iteratorAcquisitions++;
+                return {
+                    next() {
+                        return new Promise(() => {});
+                    }
+                };
+            }
+        };
+        const reader = new AsyncDicomReader();
+
+        await expect(reader.readFileFromAsyncStream(source)).rejects.toThrow(
+            "Cancellable stream must be a Node stream or ReadableStream"
+        );
+        expect(iteratorAcquisitions).toBe(0);
     });
 
     it("preserves subclasses in the static stream factory.", async () => {
@@ -108,6 +141,22 @@ describe("AsyncDicomReader", () => {
 
         expect(tagInfo.isUntilTag).toBe(true);
         expect(tagInfo.tag).toBe(TagHex.PixelData);
+    });
+
+    it("rewinds direct readTagHeader calls that pass untilTag.", () => {
+        const rowsTag = new Uint8Array([0x28, 0x00, 0x10, 0x00]);
+        const reader = new AsyncDicomReader();
+        reader.stream.addBuffer(rowsTag.buffer);
+        reader.stream.setComplete();
+
+        const tagInfo = reader.readTagHeader({
+            untilTag: "00280009",
+            stopOnGreaterTag: true
+        });
+
+        expect(tagInfo.isPastUntilTag).toBe(true);
+        expect(tagInfo.stopOffset).toBe(0);
+        expect(reader.stream.offset).toBe(0);
     });
 
     it("stops a node stream before reading pixel data when untilTag matches.", async () => {

--- a/test/async-data.test.js
+++ b/test/async-data.test.js
@@ -35,7 +35,7 @@ async function waitFor(predicate) {
     throw new Error("Timed out waiting for condition");
 }
 
-function createFailingNodeStream(buffer, error) {
+function createStalledNodeStream(buffer) {
     let hasRead = false;
     return new Readable({
         read() {
@@ -44,7 +44,6 @@ function createFailingNodeStream(buffer, error) {
             }
             hasRead = true;
             this.push(new Uint8Array(buffer));
-            queueMicrotask(() => this.destroy(error));
         }
     });
 }
@@ -73,27 +72,47 @@ describe("AsyncDicomReader", () => {
         );
     });
 
-    it("rejects Node-like sources without iterator cleanup.", async () => {
-        const source = {
-            destroy() {},
-            [Symbol.asyncIterator]() {
-                return {
-                    next() {
-                        return new Promise(() => {});
-                    }
-                };
-            }
-        };
-        const reader = new AsyncDicomReader();
+    it("preserves subclasses in the static stream factory.", async () => {
+        class CustomAsyncDicomReader extends AsyncDicomReader {}
 
-        await expect(reader.readFileFromAsyncStream(source)).rejects.toThrow(
-            "Cancellable stream must be a Node stream or ReadableStream"
+        const buffer = createSampleDicom();
+        const source = new ReadableStream({
+            start(controller) {
+                controller.enqueue(new Uint8Array(buffer));
+                controller.close();
+            }
+        });
+
+        const reader = await CustomAsyncDicomReader.readFileFromAsyncStream(
+            source,
+            {
+                untilTag: TagHex.PixelData,
+                streamOptions: {
+                    readAheadHighWaterMark: buffer.byteLength + 1
+                }
+            }
         );
+
+        expect(reader).toBeInstanceOf(CustomAsyncDicomReader);
+    });
+
+    it("normalizes untilTag in direct readTagHeader calls.", () => {
+        const pixelDataTag = new Uint8Array([0xe0, 0x7f, 0x10, 0x00]);
+        const reader = new AsyncDicomReader();
+        reader.stream.addBuffer(pixelDataTag.buffer);
+        reader.stream.setComplete();
+
+        const tagInfo = reader.readTagHeader({
+            untilTag: "(7fe0,0010)"
+        });
+
+        expect(tagInfo.isUntilTag).toBe(true);
+        expect(tagInfo.tag).toBe(TagHex.PixelData);
     });
 
     it("stops a node stream before reading pixel data when untilTag matches.", async () => {
         const filePath = "test/sample-dicom.dcm";
-        const maxReadAhead = 12;
+        const readAheadHighWaterMark = 12;
         const highWaterMark = 4;
         const reader = new AsyncDicomReader();
         const listener = new DicomMetadataListener();
@@ -105,7 +124,7 @@ describe("AsyncDicomReader", () => {
             listener,
             untilTag: TagHex.PixelData,
             includeUntilTagValue: false,
-            streamOptions: { maxReadAhead }
+            streamOptions: { readAheadHighWaterMark }
         });
 
         expect(dict[TagHex.Rows].Value[0]).toBe(512);
@@ -120,10 +139,119 @@ describe("AsyncDicomReader", () => {
         expect(reader.stopInfo.stopOffset).toBe(
             reader.stopInfo.tagStartOffset + 4
         );
+        expect(reader.stopInfo.availableBytes).toBeGreaterThanOrEqual(0);
+        expect(reader.stopInfo.loadedEndOffset).toBe(reader.stream.endOffset);
         expect(reader.stream.size).toBeLessThanOrEqual(
-            reader.stopInfo.tagStartOffset + maxReadAhead
+            reader.stopInfo.tagStartOffset + readAheadHighWaterMark
         );
         expect(stream.destroyed).toBe(true);
+    });
+
+    it("stops a Node stream with a pending read.", async () => {
+        const buffer = createSampleDicom();
+        let hasRead = false;
+        const source = new Readable({
+            read() {
+                if (!hasRead) {
+                    hasRead = true;
+                    this.push(new Uint8Array(buffer));
+                }
+            }
+        });
+        const reader = new AsyncDicomReader();
+
+        const { dict } = await reader.readFileFromAsyncStream(source, {
+            untilTag: TagHex.PixelData,
+            streamOptions: {
+                readAheadHighWaterMark: buffer.byteLength + 1
+            }
+        });
+
+        expect(dict[TagHex.PixelData]).toBeUndefined();
+        expect(source.destroyed).toBe(true);
+        expect(source.closed).toBe(true);
+    });
+
+    it("stops Node streams that suppress the close event.", async () => {
+        const buffer = createSampleDicom();
+        let hasRead = false;
+        const source = new Readable({
+            emitClose: false,
+            read() {
+                if (!hasRead) {
+                    hasRead = true;
+                    this.push(new Uint8Array(buffer));
+                }
+            }
+        });
+        const reader = new AsyncDicomReader();
+
+        const { dict } = await reader.readFileFromAsyncStream(source, {
+            untilTag: TagHex.PixelData,
+            streamOptions: {
+                readAheadHighWaterMark: buffer.byteLength + 1
+            }
+        });
+
+        expect(dict[TagHex.PixelData]).toBeUndefined();
+        expect(source.destroyed).toBe(true);
+        expect(source.closed).toBe(true);
+    });
+
+    it("rejects delayed Node teardown errors.", async () => {
+        const buffer = createSampleDicom();
+        const teardownError = new Error("delayed close failure");
+        let hasRead = false;
+        const source = new Readable({
+            read() {
+                if (!hasRead) {
+                    hasRead = true;
+                    this.push(new Uint8Array(buffer));
+                }
+            },
+            destroy(_error, callback) {
+                setTimeout(() => callback(teardownError), 0);
+            }
+        });
+        const reader = new AsyncDicomReader();
+
+        await expect(
+            reader.readFileFromAsyncStream(source, {
+                untilTag: TagHex.PixelData,
+                streamOptions: {
+                    readAheadHighWaterMark: buffer.byteLength + 1
+                }
+            })
+        ).rejects.toBe(teardownError);
+        expect(source.closed).toBe(true);
+    });
+
+    it("rejects synchronous Node teardown errors.", async () => {
+        const buffer = createSampleDicom();
+        const teardownError = new Error("synchronous close failure");
+        let hasRead = false;
+        const source = new Readable({
+            read() {
+                if (!hasRead) {
+                    hasRead = true;
+                    this.push(new Uint8Array(buffer));
+                }
+            },
+            destroy(_error, callback) {
+                callback(teardownError);
+            }
+        });
+        const reader = new AsyncDicomReader();
+
+        await expect(
+            reader.readFileFromAsyncStream(source, {
+                untilTag: TagHex.PixelData,
+                streamOptions: {
+                    readAheadHighWaterMark: buffer.byteLength + 1
+                }
+            })
+        ).rejects.toBe(teardownError);
+        expect(source.closed).toBe(true);
     });
 
     it("stops after reading an included untilTag value.", async () => {
@@ -138,7 +266,7 @@ describe("AsyncDicomReader", () => {
             listener,
             untilTag: TagHex.Rows,
             includeUntilTagValue: true,
-            streamOptions: { maxReadAhead: 12 }
+            streamOptions: { readAheadHighWaterMark: 12 }
         });
 
         expect(dict[TagHex.Rows].Value[0]).toBe(512);
@@ -155,7 +283,7 @@ describe("AsyncDicomReader", () => {
     it("waits for a ReadableStream source to cancel before resolving.", async () => {
         const buffer = createSampleDicom();
         const bytes = new Uint8Array(buffer);
-        const maxReadAhead = 12;
+        const readAheadHighWaterMark = 12;
         const highWaterMark = 4;
         let offset = 0;
         let isReadResolved = false;
@@ -187,7 +315,7 @@ describe("AsyncDicomReader", () => {
                 listener,
                 untilTag: TagHex.PixelData,
                 includeUntilTagValue: false,
-                streamOptions: { maxReadAhead }
+                streamOptions: { readAheadHighWaterMark }
             })
             .then(result => {
                 isReadResolved = true;
@@ -209,40 +337,60 @@ describe("AsyncDicomReader", () => {
     it("rejects when the source fails after enough bytes were buffered.", async () => {
         const buffer = createSampleDicom();
         const sourceError = new Error("source failed");
-        const source = createFailingNodeStream(buffer, sourceError);
+        const source = createStalledNodeStream(buffer);
         const reader = new AsyncDicomReader();
-        const listener = new DicomMetadataListener();
+        let markShouldStopEntered;
+        const shouldStopEntered = new Promise(resolve => {
+            markShouldStopEntered = resolve;
+        });
 
-        await expect(
-            reader.readFileFromAsyncStream(source, {
-                listener,
-                untilTag: TagHex.PixelData,
-                includeUntilTagValue: false,
-                streamOptions: {
-                    maxReadAhead: buffer.byteLength + 1
+        const readPromise = reader.readFileFromAsyncStream(source, {
+            shouldStop: ({ tagInfo }) => {
+                if (tagInfo.tag !== TagHex.Rows) {
+                    return false;
                 }
-            })
-        ).rejects.toBe(sourceError);
+                markShouldStopEntered();
+                return new Promise(() => {});
+            },
+            streamOptions: {
+                readAheadHighWaterMark: buffer.byteLength + 1
+            }
+        });
+
+        await shouldStopEntered;
+        source.emit("error", sourceError);
+
+        await expect(readPromise).rejects.toBe(sourceError);
     });
 
-    it("rejects abort-shaped source errors after early stop.", async () => {
+    it("rejects abort-shaped source errors while parsing is paused.", async () => {
         const buffer = createSampleDicom();
         const sourceError = new Error("upstream aborted");
         sourceError.name = "AbortError";
-        const source = createFailingNodeStream(buffer, sourceError);
+        const source = createStalledNodeStream(buffer);
         const reader = new AsyncDicomReader();
-        const listener = new DicomMetadataListener();
+        let markShouldStopEntered;
+        const shouldStopEntered = new Promise(resolve => {
+            markShouldStopEntered = resolve;
+        });
 
-        await expect(
-            reader.readFileFromAsyncStream(source, {
-                listener,
-                untilTag: TagHex.PixelData,
-                includeUntilTagValue: false,
-                streamOptions: {
-                    maxReadAhead: buffer.byteLength + 1
+        const readPromise = reader.readFileFromAsyncStream(source, {
+            shouldStop: ({ tagInfo }) => {
+                if (tagInfo.tag !== TagHex.Rows) {
+                    return false;
                 }
-            })
-        ).rejects.toBe(sourceError);
+                markShouldStopEntered();
+                return new Promise(() => {});
+            },
+            streamOptions: {
+                readAheadHighWaterMark: buffer.byteLength + 1
+            }
+        });
+
+        await shouldStopEntered;
+        source.emit("error", sourceError);
+
+        await expect(readPromise).rejects.toBe(sourceError);
     });
 
     it("rejects when the exposed pump is aborted externally.", async () => {
@@ -261,10 +409,44 @@ describe("AsyncDicomReader", () => {
         await expect(readPromise).rejects.toBe(externalError);
     });
 
+    it("rejects a late external abort after source settlement.", async () => {
+        const buffer = createSampleDicom();
+        const externalError = new Error("late STOW processing failure");
+        let markShouldStopEntered;
+        const shouldStopEntered = new Promise(resolve => {
+            markShouldStopEntered = resolve;
+        });
+        const source = new ReadableStream({
+            start(controller) {
+                controller.enqueue(new Uint8Array(buffer));
+                controller.close();
+            }
+        });
+        const reader = new AsyncDicomReader();
+        const readPromise = reader.readFileFromAsyncStream(source, {
+            shouldStop: ({ tagInfo }) => {
+                if (tagInfo.tag !== TagHex.Rows) {
+                    return false;
+                }
+                markShouldStopEntered();
+                return new Promise(() => {});
+            },
+            streamOptions: {
+                readAheadHighWaterMark: buffer.byteLength + 1
+            }
+        });
+
+        await shouldStopEntered;
+        await reader.pump.finished;
+        reader.pump.abort(externalError);
+
+        await expect(readPromise).rejects.toBe(externalError);
+    });
+
     it("stops a node stream when a sorted tag passes the requested untilTag.", async () => {
         const filePath = "test/sample-dicom.dcm";
         const missingTagBeforeRows = "(0028,0009)";
-        const maxReadAhead = 12;
+        const readAheadHighWaterMark = 12;
         const highWaterMark = 4;
         const reader = new AsyncDicomReader();
         const listener = new DicomMetadataListener();
@@ -276,7 +458,7 @@ describe("AsyncDicomReader", () => {
             listener,
             untilTag: missingTagBeforeRows,
             stopOnGreaterTag: true,
-            streamOptions: { maxReadAhead }
+            streamOptions: { readAheadHighWaterMark }
         });
 
         expect(dict[TagHex.Rows]).toBeUndefined();
@@ -434,7 +616,7 @@ describe("AsyncDicomReader", () => {
     it("stops a node stream after the shouldStop callback accepts a read tag.", async () => {
         const filePath = "test/sample-dicom.dcm";
         const fileSize = fs.statSync(filePath).size;
-        const maxReadAhead = 12;
+        const readAheadHighWaterMark = 12;
         const highWaterMark = 4;
         const reader = new AsyncDicomReader();
         const listener = new DicomMetadataListener();
@@ -445,7 +627,7 @@ describe("AsyncDicomReader", () => {
         const { dict } = await reader.readFileFromAsyncStream(stream, {
             listener,
             shouldStop: ({ tagInfo }) => tagInfo.tag === TagHex.Rows,
-            streamOptions: { maxReadAhead }
+            streamOptions: { readAheadHighWaterMark }
         });
 
         expect(dict[TagHex.Rows].Value[0]).toBe(512);

--- a/test/async-data.test.js
+++ b/test/async-data.test.js
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { Readable } from "stream";
 import { ReadableStream } from "stream/web";
 import dcmjs from "../src/index.js";
 import {
@@ -34,7 +35,62 @@ async function waitFor(predicate) {
     throw new Error("Timed out waiting for condition");
 }
 
+function createFailingNodeStream(buffer, error) {
+    let hasRead = false;
+    return new Readable({
+        read() {
+            if (hasRead) {
+                return;
+            }
+            hasRead = true;
+            this.push(new Uint8Array(buffer));
+            queueMicrotask(() => this.destroy(error));
+        }
+    });
+}
+
 describe("AsyncDicomReader", () => {
+    it("rejects unsupported stream sources instead of hanging.", async () => {
+        const reader = new AsyncDicomReader();
+
+        await expect(
+            reader.readFileFromAsyncStream(new ArrayBuffer(16))
+        ).rejects.toThrow(
+            "Async stream must be an async iterable or ReadableStream"
+        );
+    });
+
+    it("rejects non-cancellable async iterables.", async () => {
+        const source = {
+            async *[Symbol.asyncIterator]() {
+                yield new Uint8Array([1, 2, 3]);
+            }
+        };
+        const reader = new AsyncDicomReader();
+
+        await expect(reader.readFileFromAsyncStream(source)).rejects.toThrow(
+            "Cancellable stream must be a Node stream or ReadableStream"
+        );
+    });
+
+    it("rejects Node-like sources without iterator cleanup.", async () => {
+        const source = {
+            destroy() {},
+            [Symbol.asyncIterator]() {
+                return {
+                    next() {
+                        return new Promise(() => {});
+                    }
+                };
+            }
+        };
+        const reader = new AsyncDicomReader();
+
+        await expect(reader.readFileFromAsyncStream(source)).rejects.toThrow(
+            "Cancellable stream must be a Node stream or ReadableStream"
+        );
+    });
+
     it("stops a node stream before reading pixel data when untilTag matches.", async () => {
         const filePath = "test/sample-dicom.dcm";
         const maxReadAhead = 12;
@@ -66,6 +122,32 @@ describe("AsyncDicomReader", () => {
         );
         expect(reader.stream.size).toBeLessThanOrEqual(
             reader.stopInfo.tagStartOffset + maxReadAhead
+        );
+        expect(stream.destroyed).toBe(true);
+    });
+
+    it("stops after reading an included untilTag value.", async () => {
+        const filePath = "test/sample-dicom.dcm";
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+        const stream = fs.createReadStream(filePath, {
+            highWaterMark: 4
+        });
+
+        const { dict } = await reader.readFileFromAsyncStream(stream, {
+            listener,
+            untilTag: TagHex.Rows,
+            includeUntilTagValue: true,
+            streamOptions: { maxReadAhead: 12 }
+        });
+
+        expect(dict[TagHex.Rows].Value[0]).toBe(512);
+        expect(dict[TagHex.Columns]).toBeUndefined();
+        expect(reader.stopInfo).toEqual(
+            expect.objectContaining({
+                reason: "untilTag",
+                tag: TagHex.Rows
+            })
         );
         expect(stream.destroyed).toBe(true);
     });
@@ -127,26 +209,7 @@ describe("AsyncDicomReader", () => {
     it("rejects when the source fails after enough bytes were buffered.", async () => {
         const buffer = createSampleDicom();
         const sourceError = new Error("source failed");
-        let readCount = 0;
-        const source = {
-            [Symbol.asyncIterator]() {
-                return {
-                    next() {
-                        readCount++;
-                        if (readCount === 1) {
-                            return Promise.resolve({
-                                done: false,
-                                value: new Uint8Array(buffer)
-                            });
-                        }
-                        return Promise.reject(sourceError);
-                    },
-                    return() {
-                        return Promise.resolve({ done: true });
-                    }
-                };
-            }
-        };
+        const source = createFailingNodeStream(buffer, sourceError);
         const reader = new AsyncDicomReader();
         const listener = new DicomMetadataListener();
 
@@ -156,7 +219,6 @@ describe("AsyncDicomReader", () => {
                 untilTag: TagHex.PixelData,
                 includeUntilTagValue: false,
                 streamOptions: {
-                    awaitAbort: true,
                     maxReadAhead: buffer.byteLength + 1
                 }
             })
@@ -167,26 +229,7 @@ describe("AsyncDicomReader", () => {
         const buffer = createSampleDicom();
         const sourceError = new Error("upstream aborted");
         sourceError.name = "AbortError";
-        let readCount = 0;
-        const source = {
-            [Symbol.asyncIterator]() {
-                return {
-                    next() {
-                        readCount++;
-                        if (readCount === 1) {
-                            return Promise.resolve({
-                                done: false,
-                                value: new Uint8Array(buffer)
-                            });
-                        }
-                        return Promise.reject(sourceError);
-                    },
-                    return() {
-                        return Promise.resolve({ done: true });
-                    }
-                };
-            }
-        };
+        const source = createFailingNodeStream(buffer, sourceError);
         const reader = new AsyncDicomReader();
         const listener = new DicomMetadataListener();
 
@@ -196,11 +239,26 @@ describe("AsyncDicomReader", () => {
                 untilTag: TagHex.PixelData,
                 includeUntilTagValue: false,
                 streamOptions: {
-                    awaitAbort: true,
                     maxReadAhead: buffer.byteLength + 1
                 }
             })
         ).rejects.toBe(sourceError);
+    });
+
+    it("rejects when the exposed pump is aborted externally.", async () => {
+        const externalError = new Error("STOW processing failed");
+        const source = new ReadableStream({
+            pull() {
+                return new Promise(() => {});
+            }
+        });
+        const reader = new AsyncDicomReader();
+        const readPromise = reader.readFileFromAsyncStream(source);
+
+        await waitFor(() => reader.pump);
+        reader.pump.abort(externalError);
+
+        await expect(readPromise).rejects.toBe(externalError);
     });
 
     it("stops a node stream when a sorted tag passes the requested untilTag.", async () => {
@@ -328,6 +386,46 @@ describe("AsyncDicomReader", () => {
         expect(reader.stopInfo).toEqual(
             expect.objectContaining({
                 reason: "untilTag",
+                tag: TagHex.Rows
+            })
+        );
+    });
+
+    it("does not apply top-level shouldStop callbacks inside sequence items.", async () => {
+        const referencedSeriesSequence = "00081115";
+        const nestedRows = 7;
+        const buffer = createSampleDicom({
+            dict: {
+                [referencedSeriesSequence]: {
+                    vr: "SQ",
+                    Value: [
+                        {
+                            [TagHex.Rows]: {
+                                vr: "US",
+                                Value: [nestedRows]
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+        const reader = new AsyncDicomReader();
+        const listener = new DicomMetadataListener();
+
+        reader.stream.addBuffer(buffer);
+        reader.stream.setComplete();
+        const { dict } = await reader.readFile({
+            listener,
+            shouldStop: ({ tagInfo }) => tagInfo.tag === TagHex.Rows
+        });
+
+        expect(
+            dict[referencedSeriesSequence].Value[0][TagHex.Rows].Value[0]
+        ).toBe(nestedRows);
+        expect(dict[TagHex.Rows].Value[0]).toBe(defaultImage.rows);
+        expect(reader.stopInfo).toEqual(
+            expect.objectContaining({
+                reason: "shouldStop",
                 tag: TagHex.Rows
             })
         );

--- a/test/readBufferStream.test.js
+++ b/test/readBufferStream.test.js
@@ -1,4 +1,5 @@
 import { ReadBufferStream } from "../src/BufferStream";
+import { Readable } from "stream";
 import { ReadableStream } from "stream/web";
 
 const size = 128;
@@ -194,12 +195,124 @@ describe("ReadBufferStream Tests", () => {
             };
             const stream = new ReadBufferStream(null, false);
 
-            await stream.fromAsyncStream(source);
+            const pump = stream.pumpAsyncStream(source);
+            expect(pump.cancellable).toBe(false);
+            await pump.finished;
             stream.reset();
 
             expect(stream.readUint8()).toBe(1);
             expect(stream.readUint8()).toBe(2);
             expect(stream.readUint8()).toBe(3);
+        });
+
+        it("resumes a bounded pump as bytes are read.", async () => {
+            const source = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2]));
+                    controller.enqueue(new Uint8Array([3, 4]));
+                    controller.close();
+                }
+            });
+            const stream = new ReadBufferStream(null, false);
+            const pump = stream.pumpAsyncStream(source, {
+                readAheadHighWaterMark: 2
+            });
+
+            await stream.ensureAvailable(2);
+            expect(stream.readUint8()).toBe(1);
+            expect(stream.readUint8()).toBe(2);
+            await stream.ensureAvailable(2);
+            expect(stream.readUint8()).toBe(3);
+            expect(stream.readUint8()).toBe(4);
+            await pump.finished;
+
+            expect(stream.isComplete).toBe(true);
+        });
+
+        it("resumes a bounded pump after bulk cursor movement.", async () => {
+            const source = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3, 4]));
+                    controller.enqueue(new Uint8Array([5, 6]));
+                    controller.close();
+                }
+            });
+            const stream = new ReadBufferStream(null, false, {
+                littleEndian: true
+            });
+            const pump = stream.pumpAsyncStream(source, {
+                readAheadHighWaterMark: 4
+            });
+
+            await stream.ensureAvailable(4);
+            stream.readUint16Array(4);
+            await stream.ensureAvailable(2);
+            stream.toEnd();
+            await pump.finished;
+
+            expect(stream.isComplete).toBe(true);
+        });
+
+        it("cancels a source error while the pump is waiting on read-ahead.", async () => {
+            const sourceError = new Error("source failed");
+            let hasRead = false;
+            const source = new Readable({
+                read() {
+                    if (!hasRead) {
+                        hasRead = true;
+                        this.push(new Uint8Array([1, 2]));
+                    }
+                }
+            });
+            const stream = new ReadBufferStream(null, false);
+            const pump = stream.pumpAsyncStream(source, {
+                readAheadHighWaterMark: 2
+            });
+
+            await stream.ensureAvailable(2);
+            source.emit("error", sourceError);
+
+            await expect(pump.failure).rejects.toBe(sourceError);
+            await expect(pump.finished).rejects.toBe(sourceError);
+        });
+
+        it("applies the read-ahead high-water mark between source chunks.", async () => {
+            const source = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array(8));
+                }
+            });
+            const stream = new ReadBufferStream(null, false);
+            const pump = stream.pumpAsyncStream(source, {
+                readAheadHighWaterMark: 2
+            });
+
+            await stream.ensureAvailable(1);
+
+            expect(stream.size).toBe(8);
+
+            pump.stop();
+            await pump.finished;
+        });
+
+        it("cancels a Web source when chunk processing fails.", async () => {
+            let wasCancelled = false;
+            const source = new ReadableStream({
+                start(controller) {
+                    controller.enqueue("invalid chunk");
+                },
+                cancel() {
+                    wasCancelled = true;
+                }
+            });
+            const stream = new ReadBufferStream(null, false);
+            const pump = stream.pumpAsyncStream(source);
+
+            await expect(pump.finished).rejects.toThrow(
+                "Async stream chunks must be ArrayBuffer views"
+            );
+            expect(wasCancelled).toBe(true);
+            expect(source.locked).toBe(false);
         });
 
         it("cancels a ReadableStream source when stopped.", async () => {
@@ -218,7 +331,9 @@ describe("ReadBufferStream Tests", () => {
                 }
             });
             const stream = new ReadBufferStream(null, false);
-            const pump = stream.pumpAsyncStream(source, { maxReadAhead: 1 });
+            const pump = stream.pumpAsyncStream(source, {
+                readAheadHighWaterMark: 1
+            });
 
             await stream.ensureAvailable(1);
             pump.stop();
@@ -246,7 +361,9 @@ describe("ReadBufferStream Tests", () => {
                 }
             });
             const stream = new ReadBufferStream(null, false);
-            const pump = stream.pumpAsyncStream(source, { maxReadAhead: 1 });
+            const pump = stream.pumpAsyncStream(source, {
+                readAheadHighWaterMark: 1
+            });
             const externalError = new Error("storage failed");
 
             await stream.ensureAvailable(1);

--- a/test/readBufferStream.test.js
+++ b/test/readBufferStream.test.js
@@ -1,4 +1,4 @@
-import { ReadBufferStream } from "../src/BufferStream";
+import { ReadBufferStream, WriteBufferStream } from "../src/BufferStream";
 import { Readable } from "stream";
 import { ReadableStream } from "stream/web";
 
@@ -7,6 +7,32 @@ const buffer = new ArrayBuffer(size);
 const dataView = new DataView(buffer);
 for (let i = 0; i < size; i++) {
     dataView.setUint8(i, i % 256);
+}
+
+function createCountingAsyncSource(chunks) {
+    let index = 0;
+    let nextCalls = 0;
+    return {
+        source: {
+            [Symbol.asyncIterator]() {
+                return {
+                    next() {
+                        nextCalls++;
+                        if (index >= chunks.length) {
+                            return Promise.resolve({ done: true });
+                        }
+                        return Promise.resolve({
+                            done: false,
+                            value: chunks[index++]
+                        });
+                    }
+                };
+            }
+        },
+        get nextCalls() {
+            return nextCalls;
+        }
+    };
 }
 
 describe("ReadBufferStream Tests", () => {
@@ -156,6 +182,17 @@ describe("ReadBufferStream Tests", () => {
             expect(stream.isAvailable(remaining, false)).toBe(true);
             expect(stream.isAvailable(remaining + 1, false)).toBe(false);
         });
+
+        it("rechecks pending availability after reset.", async () => {
+            const stream = new ReadBufferStream(null, false);
+            stream.addBuffer(new ArrayBuffer(4));
+            stream.increment(4);
+            const available = stream.ensureAvailable(4);
+
+            stream.reset();
+
+            await expect(available).resolves.toBe(true);
+        });
     });
 
     describe("async stream pumping", () => {
@@ -206,51 +243,77 @@ describe("ReadBufferStream Tests", () => {
         });
 
         it("resumes a bounded pump as bytes are read.", async () => {
-            const source = new ReadableStream({
-                start(controller) {
-                    controller.enqueue(new Uint8Array([1, 2]));
-                    controller.enqueue(new Uint8Array([3, 4]));
-                    controller.close();
-                }
-            });
+            const countedSource = createCountingAsyncSource([
+                new Uint8Array([1, 2]),
+                new Uint8Array([3, 4])
+            ]);
             const stream = new ReadBufferStream(null, false);
-            const pump = stream.pumpAsyncStream(source, {
+            const pump = stream.pumpAsyncStream(countedSource.source, {
                 readAheadHighWaterMark: 2
             });
 
             await stream.ensureAvailable(2);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(countedSource.nextCalls).toBe(1);
             expect(stream.readUint8()).toBe(1);
             expect(stream.readUint8()).toBe(2);
             await stream.ensureAvailable(2);
+            expect(countedSource.nextCalls).toBe(2);
             expect(stream.readUint8()).toBe(3);
             expect(stream.readUint8()).toBe(4);
             await pump.finished;
 
             expect(stream.isComplete).toBe(true);
+            expect(countedSource.nextCalls).toBe(3);
         });
 
         it("resumes a bounded pump after bulk cursor movement.", async () => {
-            const source = new ReadableStream({
-                start(controller) {
-                    controller.enqueue(new Uint8Array([1, 2, 3, 4]));
-                    controller.enqueue(new Uint8Array([5, 6]));
-                    controller.close();
-                }
-            });
-            const stream = new ReadBufferStream(null, false, {
-                littleEndian: true
-            });
-            const pump = stream.pumpAsyncStream(source, {
+            const countedSource = createCountingAsyncSource([
+                new Uint8Array([1, 2, 3, 4]),
+                new Uint8Array([5, 6])
+            ]);
+            const stream = new ReadBufferStream(null, true);
+            const pump = stream.pumpAsyncStream(countedSource.source, {
                 readAheadHighWaterMark: 4
             });
 
             await stream.ensureAvailable(4);
-            stream.readUint16Array(4);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(countedSource.nextCalls).toBe(1);
+            const values = stream.readUint16Array(4);
+            expect(Array.from(values)).toEqual([513, 1027]);
             await stream.ensureAvailable(2);
+            expect(countedSource.nextCalls).toBe(2);
             stream.toEnd();
             await pump.finished;
 
             expect(stream.isComplete).toBe(true);
+            expect(countedSource.nextCalls).toBe(3);
+        });
+
+        it("resumes a bounded pump after concat advances the cursor.", async () => {
+            const countedSource = createCountingAsyncSource([
+                new Uint8Array([1, 2, 3, 4]),
+                new Uint8Array([5, 6])
+            ]);
+            const stream = new WriteBufferStream(4, false);
+            const consumed = new WriteBufferStream(4, false);
+            consumed.writeUint8Repeat(0, 4);
+            consumed.reset();
+            const pump = stream.pumpAsyncStream(countedSource.source, {
+                readAheadHighWaterMark: 4
+            });
+
+            await stream.ensureAvailable(4);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(countedSource.nextCalls).toBe(1);
+
+            stream.concat(consumed);
+            await stream.ensureAvailable(2);
+
+            expect(countedSource.nextCalls).toBe(2);
+            pump.stop();
+            await pump.finished;
         });
 
         it("cancels a source error while the pump is waiting on read-ahead.", async () => {
@@ -277,19 +340,20 @@ describe("ReadBufferStream Tests", () => {
         });
 
         it("applies the read-ahead high-water mark between source chunks.", async () => {
-            const source = new ReadableStream({
-                start(controller) {
-                    controller.enqueue(new Uint8Array(8));
-                }
-            });
+            const countedSource = createCountingAsyncSource([
+                new Uint8Array(8),
+                new Uint8Array(1)
+            ]);
             const stream = new ReadBufferStream(null, false);
-            const pump = stream.pumpAsyncStream(source, {
+            const pump = stream.pumpAsyncStream(countedSource.source, {
                 readAheadHighWaterMark: 2
             });
 
             await stream.ensureAvailable(1);
+            await new Promise(resolve => setTimeout(resolve, 0));
 
             expect(stream.size).toBe(8);
+            expect(countedSource.nextCalls).toBe(1);
 
             pump.stop();
             await pump.finished;
@@ -313,6 +377,23 @@ describe("ReadBufferStream Tests", () => {
             );
             expect(wasCancelled).toBe(true);
             expect(source.locked).toBe(false);
+        });
+
+        it("normalizes reasonless source rejections.", async () => {
+            const source = {
+                [Symbol.asyncIterator]() {
+                    return {
+                        next() {
+                            return Promise.reject();
+                        }
+                    };
+                }
+            };
+            const stream = new ReadBufferStream(null, false);
+            const pump = stream.pumpAsyncStream(source);
+
+            await expect(pump.failure).rejects.toThrow("Async source failed");
+            await expect(pump.finished).rejects.toThrow("Async source failed");
         });
 
         it("cancels a ReadableStream source when stopped.", async () => {

--- a/test/readBufferStream.test.js
+++ b/test/readBufferStream.test.js
@@ -1,5 +1,4 @@
 import { ReadBufferStream } from "../src/BufferStream";
-import { Readable } from "stream";
 import { ReadableStream } from "stream/web";
 
 const size = 128;
@@ -159,6 +158,14 @@ describe("ReadBufferStream Tests", () => {
     });
 
     describe("async stream pumping", () => {
+        it("rejects unsupported stream sources synchronously.", () => {
+            const stream = new ReadBufferStream(null, false);
+
+            expect(() => stream.pumpAsyncStream(new ArrayBuffer(16))).toThrow(
+                "Async stream must be an async iterable or ReadableStream"
+            );
+        });
+
         it("reads chunks from a ReadableStream source.", async () => {
             const source = new ReadableStream({
                 start(controller) {
@@ -178,9 +185,25 @@ describe("ReadBufferStream Tests", () => {
             expect(source.locked).toBe(false);
         });
 
-        it("cancels a ReadableStream source when aborted.", async () => {
-            const cancelReason = new Error("stop reading");
-            let receivedCancelReason;
+        it("retains low-level support for generic async iterables.", async () => {
+            const source = {
+                async *[Symbol.asyncIterator]() {
+                    yield new Uint8Array([1, 2]);
+                    yield new Uint8Array([3]);
+                }
+            };
+            const stream = new ReadBufferStream(null, false);
+
+            await stream.fromAsyncStream(source);
+            stream.reset();
+
+            expect(stream.readUint8()).toBe(1);
+            expect(stream.readUint8()).toBe(2);
+            expect(stream.readUint8()).toBe(3);
+        });
+
+        it("cancels a ReadableStream source when stopped.", async () => {
+            let receivedStopReason;
             let resolveCancel;
             let isFinished = false;
             const source = new ReadableStream({
@@ -188,7 +211,7 @@ describe("ReadBufferStream Tests", () => {
                     controller.enqueue(new Uint8Array([1, 2, 3]));
                 },
                 cancel(reason) {
-                    receivedCancelReason = reason;
+                    receivedStopReason = reason;
                     return new Promise(resolve => {
                         resolveCancel = resolve;
                     });
@@ -198,7 +221,7 @@ describe("ReadBufferStream Tests", () => {
             const pump = stream.pumpAsyncStream(source, { maxReadAhead: 1 });
 
             await stream.ensureAvailable(1);
-            pump.abort(cancelReason);
+            pump.stop();
             const finished = pump.finished.then(() => {
                 isFinished = true;
             });
@@ -209,25 +232,28 @@ describe("ReadBufferStream Tests", () => {
             resolveCancel();
             await finished;
 
-            expect(receivedCancelReason).toBe(cancelReason);
-            expect(pump.aborted).toBe(true);
+            expect(receivedStopReason).toBeInstanceOf(Error);
+            expect(pump.aborted).toBe(false);
+            expect(pump.stopped).toBe(true);
             expect(stream.isComplete).toBe(true);
             expect(source.locked).toBe(false);
         });
 
-        it("does not destroy a Node stream when destroyOnAbort is false.", async () => {
-            const source = Readable.from([new Uint8Array([1, 2, 3])]);
-            const stream = new ReadBufferStream(null, false);
-            const pump = stream.pumpAsyncStream(source, {
-                destroyOnAbort: false,
-                maxReadAhead: 1
+        it("rejects when aborted by an external error.", async () => {
+            const source = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3]));
+                }
             });
+            const stream = new ReadBufferStream(null, false);
+            const pump = stream.pumpAsyncStream(source, { maxReadAhead: 1 });
+            const externalError = new Error("storage failed");
 
             await stream.ensureAvailable(1);
-            pump.abort(new Error("stop reading"));
-            await pump.finished;
+            pump.abort(externalError);
 
-            expect(source.destroyed).toBe(false);
+            await expect(pump.finished).rejects.toBe(externalError);
+            expect(pump.aborted).toBe(true);
         });
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rejects unsupported and non-cancellable convenience sources before iterator acquisition, preventing hangs, iterator leaks, and unhandled rejections.
- Distinguishes successful parser completion (`stop`) from external workflow failure (`abort(error)`), preserving reasonless, source, cancellation, parser, and late external errors.
- Fixes `untilTag` with `includeUntilTagValue: true`, nested `shouldStop` scoping, and source failure propagation through availability waits.
- Closes Node lifecycle races: pending reads are interrupted, teardown is awaited through close or `emitClose: false`, and synchronous/delayed `_destroy` errors are preserved.
- Restores bounded-pump wakeups for every cursor movement path and cancels sources after chunk-processing failures.
- Clarifies `readAheadHighWaterMark`, direct `readTagHeader()` cursor behavior, and `stopInfo` fields.

## Review guide

- Review `src/BufferStream.js` for the independent failure/stop signals, serialized finalization, Node/Web adapters, close/error handling, and bounded read-ahead wakeups.
- Review `src/AsyncDicomReader.js` to confirm parsing races the pump failure signal, late `abort(error)` remains effective after source settlement, and direct greater-tag reads rewind consistently.
- Review the pull-counted regressions in `test/readBufferStream.test.js`; they assert the next source read is genuinely blocked until cursor advancement.
- Review lifecycle regressions in `test/async-data.test.js` for pending Node reads, late abort, reasonless failures, synchronous/delayed teardown errors, and `emitClose: false`.

## Safety

- `readFileFromAsyncStream()` accepts reliably cancellable Node streams and Web `ReadableStream`s.
- Existing low-level `BufferStream.fromAsyncStream()` support for generic async iterables remains available and exposes `cancellable: false` where interruption is not guaranteed.
- Node successful stop is error-free and awaits actual teardown; external abort uses the supplied error.
- `readAheadHighWaterMark` is checked between atomic source chunks, so one source chunk may exceed the threshold.
- `pump.abort(error)` rejects pending reads; callers must still await their external processing promise because fulfilled promises cannot be retroactively rejected.

## Performance

Interleaved same-process benchmark against `dcmjs-org/master` (`81e7e11`) on Node 22.14, built bundles, 11 alternating rounds, `test/sample-dicom.dcm` (~528 KB):

| Operation | Upstream median | This branch median | Difference |
|---|---:|---:|---:|
| Sync read | 0.3603 ms | 0.3738 ms | +3.74% |
| Sync write | 2.3704 ms | 2.3688 ms | -0.07% |
| Async full read | 0.6327 ms | 0.6670 ms | +5.42% |
| Async metadata-only | 0.5198 ms | 0.5555 ms | +6.85% |

The largest measured absolute difference is about 0.036 ms per file.

## Test plan

- [x] Full Node 22 suite (`360` tests)
- [x] Full Node 24 suite (`360` tests)
- [x] Pull-counted backpressure tests that fail when limiting is disabled
- [x] Reasonless/falsy source failure regressions
- [x] Pending read, late abort, and source settlement races
- [x] Synchronous/delayed Node teardown errors and `emitClose: false`
- [x] Web cancellation after chunk-processing failure
- [x] Reset, bulk cursor, `toEnd()`, and `concat()` wakeups
- [x] ESLint and Prettier
- [x] Production Rollup build
- [x] Interleaved current-vs-upstream performance benchmark
- [x] Three parallel adversarial reviews plus post-fix verification
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4773b57-f3b7-4008-8a46-93e83691208e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4773b57-f3b7-4008-8a46-93e83691208e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

